### PR TITLE
fix(style): eodash page layout

### DIFF
--- a/sentinelexplorer/index.md
+++ b/sentinelexplorer/index.md
@@ -4,7 +4,10 @@ footer: false
 ---
 
 <script setup>
-    const config = async() => (await import("./sentinel-explorer-config")).default
+  if (document.querySelector(".layout-home")) {
+    window.location.reload();
+  }
+  const config = async() => (await import("./sentinel-explorer-config")).default
 </script>
 
 <style scoped>


### PR DESCRIPTION
Fixing the eodash page layout:
- use page layout (in order to use default navbar)
- using no footer
- setting `eo-dash` width and height
- removing padding for page with `eo-dash`
- added "safety net" page hard reload in case the home page layout gets "stuck"