### PR TITLE
chore(deps): update elements packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@eox/layercontrol": "^1.3.2",
         "@eox/layout": "^1.0.0",
         "@eox/map": "^2.0.2",
-        "@eox/storytelling": "^1.9.8"
+        "@eox/storytelling": "^1.10.0"
       },
       "devDependencies": {
         "@eox/pages-theme-eox": "^0.11.1",
@@ -1735,9 +1735,9 @@
       }
     },
     "node_modules/@eox/storytelling": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/@eox/storytelling/-/storytelling-1.9.8.tgz",
-      "integrity": "sha512-hUY3XMIgvinVf71KB4KSnvRqD8Ru3T4j56k20pJPOmX06QTcIWS+wmUHLbN7lsS90v965tPFlGXwIM8Qkj1HJw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@eox/storytelling/-/storytelling-1.10.0.tgz",
+      "integrity": "sha512-vwD0jQpO7FRQhm2Pdk/K5kwY9IBAiWnSuLxpdWw0i7eQaq5ghykOBsZZ4usuHlXZ2ZvJO19dhmdhitMCPacghw==",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
         "@eox/ui": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@eox/layercontrol": "^1.3.2",
     "@eox/layout": "^1.0.0",
     "@eox/map": "^2.0.2",
-    "@eox/storytelling": "^1.9.8"
+    "@eox/storytelling": "^1.10.0"
   },
   "devDependencies": {
     "@eox/pages-theme-eox": "^0.11.1",


### PR DESCRIPTION
Updates the EOxElements including `eox-map` v2 (requires narratives map layers to be reversed).

Follow-up PR: https://github.com/EOPF-Explorer/narratives/pull/7