### PR TITLE
Feat: Sentinel 1 Enhancements

### DIFF
--- a/.vitepress/components/CookieToggles.vue
+++ b/.vitepress/components/CookieToggles.vue
@@ -64,7 +64,7 @@ let analyticsInput = null;
 
 const onAnalyticsToggle = () => {
   /** @type {any[]} */
-  //@ts-expect-error provided internally 
+  //@ts-expect-error provided internally
   const paq = window._paq;
   if (analyticsInput?.checked) {
     paq.push(["forgetUserOptOut"]);

--- a/.vitepress/components/EOPFFooter.vue
+++ b/.vitepress/components/EOPFFooter.vue
@@ -53,10 +53,14 @@
             >
           </p>
           <p>
-            <a :href="withBase('/privacy-policy')" class="link">Privacy Policy</a>
+            <a :href="withBase('/privacy-policy')" class="link"
+              >Privacy Policy</a
+            >
           </p>
           <p>
-            <a :href="withBase('/cookie-settings')" class="link">Cookie Settings</a>
+            <a :href="withBase('/cookie-settings')" class="link"
+              >Cookie Settings</a
+            >
           </p>
         </div>
       </div>

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -56,7 +56,7 @@ export default defineConfig({
     externalLinkIcon:true,
     nav: [
       { text: "Data Catalog", link: "https://api.explorer.eopf.copernicus.eu/browser" },
-      { text: "Dynamic Browser", link: "/sentinelexplorer/?template=explore&indicator=sentinel-2-l2a" },
+      { text: "Dynamic Browser", link: "/sentinelexplorer/?template=explore" },
       { text: "Software & Services", link: "/software-services" },
       { text: "Webinars & Events", link: "/webinars-events" },
       { text: "Documentation", link: "https://eopf-explorer.github.io/data-model/" },

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -3,6 +3,7 @@ import EOX from "@eox/pages-theme-eox";
 import "./custom.css";
 import EOPFFooter from "../components/EOPFFooter.vue";
 import CookieToggles from "../components/CookieToggles.vue";
+import { resolveStacItemRedirect } from "../utils/redirects";
 
 /** @type {import('vitepress').Theme} */
 export default {
@@ -14,8 +15,14 @@ export default {
     app.component("Footer", EOPFFooter);
     app.component("CookieToggles", CookieToggles);
 
-    //@ts-expect-error special vitepress property
     if (!import.meta.env.SSR) {
+      // redirect items eopf-explorer link
+      const stacRedirect = resolveStacItemRedirect(window.location.pathname);
+      if (stacRedirect) {
+        window.location.replace(stacRedirect);
+        return;
+      }
+
       // Monkey patch customElements.define to prevent "already defined" errors
       const originalDefine = customElements.define;
       customElements.define = function (name, constructor, options) {

--- a/.vitepress/utils/redirects.js
+++ b/.vitepress/utils/redirects.js
@@ -1,0 +1,20 @@
+/**
+ * Maps a STAC catalogue deep link to its Sentinel Explorer equivalent, so that
+ * `/collections/sentinel-2-l2a/items/S2B_MSIL2A_20260727T084559_...` opens as
+ * `/sentinelexplorer/?indicator=sentinel-2-l2a&item=S2B_MSIL2A_20260727T084559_...`.
+ *
+ * @param {string} pathname
+ * @returns {string | null} Sentinel Explorer URL, or null if the path is not a STAC item link.
+ */
+export const resolveStacItemRedirect = (pathname) => {
+  const match = /^\/collections\/([^/]+)\/items\/([^/]+)\/?$/.exec(pathname);
+  if (!match) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    indicator: decodeURIComponent(match[1]),
+    item: decodeURIComponent(match[2]),
+  });
+  return `/sentinelexplorer/?${params}`;
+};

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ hero:
   actions:
     # - theme: brand
     #   text: Explore Data
-    #   link: /sentinelexplorer/?template=explore&indicator=sentinel-2-l2a
+    #   link: /sentinelexplorer/?template=explore
     - theme: brand
       text: Webinars & Events
       link: /webinars-events
@@ -78,7 +78,7 @@ Experience how EOPF Sentinel Zarr powers effortless exploration of Sentinel data
   image="media/cloudless.png"
   landing
   primaryButton="Open Explorer"
-  primaryLink="/sentinelexplorer/?template=explore&indicator=sentinel-2-l2a"
+  primaryLink="/sentinelexplorer/?template=explore"
   tagline="Explore Sentinel data in real time"
   title="Sentinels Browser"
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,27 +8,27 @@
       "name": "eopf-explorer-landing-page",
       "version": "2.0.0",
       "dependencies": {
-        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@7e9e987",
-        "@eox/chart": "^1.1.0",
-        "@eox/drawtools": "^1.4.0",
-        "@eox/elements-utils": "^1.1.1",
-        "@eox/itemfilter": "^1.15.0",
-        "@eox/jsonform": "^1.11.0",
-        "@eox/layercontrol": "^1.5.0",
+        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@d8b99b2",
+        "@eox/chart": "^1.2.0",
+        "@eox/drawtools": "^1.6.0",
+        "@eox/elements-utils": "^1.2.0",
+        "@eox/itemfilter": "^1.17.3",
+        "@eox/jsonform": "^1.12.1",
+        "@eox/layercontrol": "^1.8.0",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "^2.4.0",
-        "@eox/storytelling": "^1.11.0",
-        "@eox/timecontrol": "^2.3.0",
+        "@eox/map": "^2.7.0",
+        "@eox/storytelling": "^1.13.0",
+        "@eox/timecontrol": "^2.6.0",
         "chroma-js": "^3.2.0",
         "ol": "10.9.0",
         "stac-js": "^0.1.9"
       },
       "devDependencies": {
-        "@eox/pages-theme-eox": "^1.6.0",
+        "@eox/pages-theme-eox": "^1.9.0",
         "@types/chroma-js": "^3.1.2",
-        "eslint-plugin-vue": "^10.9.0",
+        "eslint-plugin-vue": "^10.9.2",
         "typescript": "^5.9.3",
-        "vue-tsc": "^3.2.8"
+        "vue-tsc": "^3.3.6"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@eodash/eodash": {
-      "version": "5.7.0",
-      "resolved": "https://pkg.pr.new/@eodash/eodash@7e9e987",
-      "integrity": "sha512-0JEUqSktko2uyeWRrLpnMDWjXUtG2ivMn6lqcNQUlVBvi3VvDm9NHERb1CBFWBtdJl5nnRP7z+I56Xm+hCZusw==",
+      "version": "5.7.1",
+      "resolved": "https://pkg.pr.new/@eodash/eodash@d8b99b2",
+      "integrity": "sha512-zSCUM2u+qd3rNLcep8k3SFOhj9MO/1P/SfoaAm/+rQL3n0aAwSqGhawFkyDX4bzrCMFhaBDWRFkJBMX+m2Rx+g==",
       "dependencies": {
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
@@ -612,11 +612,11 @@
         "@eox/geosearch": "^1.2.0",
         "@eox/itemfilter": "^1.17.3",
         "@eox/jsonform": "^1.12.1",
-        "@eox/layercontrol": "^1.7.0",
+        "@eox/layercontrol": "^1.8.0",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "^2.6.1",
+        "@eox/map": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
         "@eox/stacinfo": "^1.2.0",
-        "@eox/timecontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/timecontrol@476eb30",
+        "@eox/timecontrol": "^2.6.0",
         "@eox/ui": "^1.1.0",
         "@mdi/js": "^7.4.47",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -1288,8 +1288,8 @@
     },
     "node_modules/@eox/elements-utils": {
       "version": "1.2.0",
-      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/elements-utils@476eb30400cd1eb84a18869610ece33e5ba3e50f",
-      "integrity": "sha512-xMqkbMsmchnvpQSUeus57n7J6gW23QiS/AzP9TQkoEjMTsMZO0lLUNV+/vfTjuOUVLgzK+iSySF0CwRh06O86A==",
+      "resolved": "https://registry.npmjs.org/@eox/elements-utils/-/elements-utils-1.2.0.tgz",
+      "integrity": "sha512-b7P2AkqaHlMAv+/+uuyI4FlEnDgKgLG4lc1hlUNe/lfXPtUjg/UcmqqJjI7EnQNXAQPP6vQGoSZjRSx1JFpFHg==",
       "dependencies": {
         "@eox/ui": "^1.1.0"
       }
@@ -1682,14 +1682,14 @@
       }
     },
     "node_modules/@eox/layercontrol": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@eox/layercontrol/-/layercontrol-1.7.0.tgz",
-      "integrity": "sha512-0UEgKmxRM5eJkMbrPybkxUWQAbepJ4FRRsmYzO7bYvY6nfBKkeq64aNIVtmslnB4z0m/cr7vA2MarSIMOy8sXQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@eox/layercontrol/-/layercontrol-1.8.0.tgz",
+      "integrity": "sha512-5rsTkmHryOGL7q8N3IiFouRjNOzCzdDXy21ntzAFBKWEi0rp0u07ms4WvXK8e3ULqFA5jS2LtvrHYp9aMiEUwA==",
       "dependencies": {
-        "@eox/elements-utils": "^1.1.0",
+        "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
         "color-legend-element": "^1.5.0",
-        "lit": "^3.2.0",
+        "lit": "^3.3.3",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "sortablejs": "^1.15.0",
@@ -1710,9 +1710,9 @@
       "integrity": "sha512-+n5Ym18Bq9l6isyK0DexMrba/eD0uPhqLgtS2BPrFHyEQ0m/T8n3nTDl/wu7zI9V3Vf9mw9KurhrD/oJGth5gw=="
     },
     "node_modules/@eox/map": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@eox/map/-/map-2.6.1.tgz",
-      "integrity": "sha512-0t1vRAN/nUI5dp0rnJc+9vcNIpTtFAgs+NA32aPJHeg687tM5UJZV73uCwdYfQoo5m/sc0WcA5WXNrS9J1E0jQ==",
+      "version": "2.7.0",
+      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
+      "integrity": "sha512-7jKOx/AgFwqTmFN7lYMxQKh48CUdQ34q4FI+CjVWwij6Czbn1vrE4LyPM4+coXvuwdPTTpxR4uFQzAamou8uYA==",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
@@ -1722,7 +1722,7 @@
         "ol": "^10.9.0",
         "ol-mapbox-style": "^13.4.1",
         "ol-stac": "^1.4.0",
-        "proj4": "^2.20.8",
+        "proj4": "^2.20.9",
         "serialize-javascript": "^7.0.1"
       },
       "engines": {
@@ -1731,9 +1731,9 @@
       }
     },
     "node_modules/@eox/pages-theme-eox": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@eox/pages-theme-eox/-/pages-theme-eox-1.6.0.tgz",
-      "integrity": "sha512-RU8Z/TV4eFLhRftxLQmiiCssLA29KO/V4IhRFvqhxp4UXkS9zz2qV4kqLMjdxlXHegWydT9lJcipPqbmxXprEA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@eox/pages-theme-eox/-/pages-theme-eox-1.9.0.tgz",
+      "integrity": "sha512-yJH2Ut9vShaRNkTrOCqEZM4lsrajGtnoc474CeDbxggECtw+EeDB4RAaLfUFTWGdR/iHDLde6Dh+P/KX6iX+dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1741,6 +1741,9 @@
         "@eox/feedback": "^1.1.1",
         "@eox/ui": "^1.0.1",
         "vitepress": "^1.6.3"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@eox/stacinfo": {
@@ -1759,24 +1762,24 @@
       }
     },
     "node_modules/@eox/storytelling": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@eox/storytelling/-/storytelling-1.11.0.tgz",
-      "integrity": "sha512-W3LckDfMBMSflkBMsbS1WZoQm1nLmFsEN8yQ6orZzNmakV14VuTCRm5+tFF14gooo+tOF5ykyhJcrtm1IIosgQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@eox/storytelling/-/storytelling-1.13.0.tgz",
+      "integrity": "sha512-0G4oFYXDOtYRbRTfLaskag70XVP5OUbtO+XczV9Bnma3ymUiUzao9a1p2QlhMgNNfST9tO71SstDAHfBlc66sw==",
       "dependencies": {
-        "@eox/elements-utils": "^1.1.0",
+        "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
         "@sindresorhus/slugify": "^3.0.0",
         "glightbox": "^3.3.0",
-        "isomorphic-dompurify": "^3.8.0",
-        "joi": "^18.1.2",
-        "js-yaml": "^4.1.0",
-        "lit": "^3.2.0",
+        "isomorphic-dompurify": "^3.17.0",
+        "joi": "^18.2.1",
+        "js-yaml": "^4.2.0",
+        "lit": "^3.3.3",
         "lodash.debounce": "^4.0.8",
         "markdown-it": "^14.0.0",
         "markdown-it-footnote": "^4.0.0"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=24.0.0",
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
@@ -1784,17 +1787,18 @@
       }
     },
     "node_modules/@eox/timecontrol": {
-      "version": "2.5.1",
-      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/timecontrol@476eb30",
-      "integrity": "sha512-6jnGu1YEzEoxcniCoc9uHxepCnbOZSppEC+1hnkKSDOazpsG0g0R+Ob9yMCG5qI3q29Q1yK9pMhEebs+Y569Gg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@eox/timecontrol/-/timecontrol-2.6.0.tgz",
+      "integrity": "sha512-J/l4fHJ9CtD8gbhR5wlMwkQK7SHOi0ml6cmsAXIENQeL3nNptuBiolxvXUdNmX/3y1dNrQSvO/4Ga3SJ+7sXrg==",
       "dependencies": {
-        "@eox/elements-utils": "https://pkg.pr.new/EOX-A/EOxElements/@eox/elements-utils@476eb30400cd1eb84a18869610ece33e5ba3e50f",
+        "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "dayjs": "^1.11.21",
         "gifshot": "^0.4.5",
         "lit": "^3.3.3",
+        "lodash.filter": "^4.6.0",
         "lodash.find": "^4.6.0",
         "lodash.findindex": "^4.6.0",
         "lodash.groupby": "^4.6.0",
@@ -2561,9 +2565,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/tlds": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
-      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
@@ -4431,16 +4435,16 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.8.tgz",
-      "integrity": "sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.6.tgz",
+      "integrity": "sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.1.2",
+        "alien-signals": "^3.2.0",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
         "picomatch": "^4.0.4"
@@ -4755,9 +4759,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
-      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5968,9 +5972,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
-      "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz",
+      "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5988,7 +5992,7 @@
         "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "vue-eslint-parser": "^10.0.0"
+        "vue-eslint-parser": "^10.3.0"
       },
       "peerDependenciesMeta": {
         "@stylistic/eslint-plugin": {
@@ -6851,9 +6855,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -6869,9 +6873,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7059,6 +7073,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ==",
       "license": "MIT"
     },
     "node_modules/lodash.find": {
@@ -7985,9 +8005,9 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.20.8",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
-      "integrity": "sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==",
+      "version": "2.20.9",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
+      "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
@@ -7995,6 +8015,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ahocevar"
+      },
+      "peerDependencies": {
+        "geotiff": "*"
+      },
+      "peerDependenciesMeta": {
+        "geotiff": {
+          "optional": true
+        }
       }
     },
     "node_modules/propagating-hammerjs": {
@@ -10273,14 +10301,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.8.tgz",
-      "integrity": "sha512-27vTLJ6Q2370obOd0PFYoYoKnmXJ521uUIedrs3Zhhhg/8YG10VOCMmwt+JQslatpAMTDbnWiitLnoD5VlIvog==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.6.tgz",
+      "integrity": "sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.2.8"
+        "@vue/language-core": "3.3.6"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "eopf-explorer-landing-page",
       "version": "2.0.0",
       "dependencies": {
-        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@d8b99b2",
+        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@9c97499",
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
         "@eox/elements-utils": "^1.2.0",
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@eodash/eodash": {
-      "version": "5.7.1",
-      "resolved": "https://pkg.pr.new/@eodash/eodash@d8b99b2",
-      "integrity": "sha512-zSCUM2u+qd3rNLcep8k3SFOhj9MO/1P/SfoaAm/+rQL3n0aAwSqGhawFkyDX4bzrCMFhaBDWRFkJBMX+m2Rx+g==",
+      "version": "5.8.0",
+      "resolved": "https://pkg.pr.new/@eodash/eodash@9c97499",
+      "integrity": "sha512-D5gnuWjv9XK2RQY8O2+FtsSH1qF+vBJeW1ZHCHi3CX/xLrLAy6gBYUIyAuAcZ+v44uVA9v87jogJeWrW7npfIg==",
       "dependencies": {
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "eopf-explorer-landing-page",
       "version": "2.0.0",
       "dependencies": {
-        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@9c97499",
+        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@08af85a",
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
         "@eox/elements-utils": "^1.2.0",
         "@eox/itemfilter": "^1.17.3",
         "@eox/jsonform": "^1.12.1",
-        "@eox/layercontrol": "^1.8.0",
+        "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@7eb12be",
         "@eox/layout": "^1.0.0",
         "@eox/map": "^2.7.0",
         "@eox/storytelling": "^1.13.0",
@@ -603,8 +603,8 @@
     },
     "node_modules/@eodash/eodash": {
       "version": "5.8.0",
-      "resolved": "https://pkg.pr.new/@eodash/eodash@9c97499",
-      "integrity": "sha512-D5gnuWjv9XK2RQY8O2+FtsSH1qF+vBJeW1ZHCHi3CX/xLrLAy6gBYUIyAuAcZ+v44uVA9v87jogJeWrW7npfIg==",
+      "resolved": "https://pkg.pr.new/@eodash/eodash@08af85a",
+      "integrity": "sha512-0Vp9U2aEGVxjpBmbcJC83T6MbVIzz0GBEoDMolvp9oH4thuJD3WhHgI7CJjdZhoucRDXLC5Luf5ai2mI438YVQ==",
       "dependencies": {
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
@@ -612,9 +612,9 @@
         "@eox/geosearch": "^1.2.0",
         "@eox/itemfilter": "^1.17.3",
         "@eox/jsonform": "^1.12.1",
-        "@eox/layercontrol": "^1.8.0",
+        "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@bbc3b0b",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
+        "@eox/map": "^2.7.0",
         "@eox/stacinfo": "^1.2.0",
         "@eox/timecontrol": "^2.6.0",
         "@eox/ui": "^1.1.0",
@@ -650,6 +650,29 @@
       },
       "engines": {
         "node": ">=20.15.1"
+      }
+    },
+    "node_modules/@eodash/eodash/node_modules/@eox/layercontrol": {
+      "version": "1.8.2",
+      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@bbc3b0b",
+      "integrity": "sha512-D3bsz5m9U8oD7E62In1sBv665/pXbrdvpbDkhBle6tP3LyOFVoZLFYinQ6bYuKEjFGDQ5l4hl+uR5jrZQwhWDA==",
+      "dependencies": {
+        "@eox/elements-utils": "^1.2.0",
+        "@eox/ui": "^1.1.0",
+        "color-legend-element": "^1.5.0",
+        "lit": "^3.3.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "sortablejs": "^1.15.0",
+        "wms-capabilities": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@eox/jsonform": "*",
+        "@eox/timecontrol": ">=2.0.0"
       }
     },
     "node_modules/@eodash/eodash/node_modules/stac-js": {
@@ -1683,8 +1706,8 @@
     },
     "node_modules/@eox/layercontrol": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@eox/layercontrol/-/layercontrol-1.8.0.tgz",
-      "integrity": "sha512-5rsTkmHryOGL7q8N3IiFouRjNOzCzdDXy21ntzAFBKWEi0rp0u07ms4WvXK8e3ULqFA5jS2LtvrHYp9aMiEUwA==",
+      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@7eb12be",
+      "integrity": "sha512-6HgDfkhM8lxPcsYpk59kqLZz+y7PdsYMqfzlqH8YtgWwFC7KgDG2sgwVSWnbobKd9uJzvkAFaFtz4XoT48j9sg==",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check": "vue-tsc && eslint ."
   },
   "dependencies": {
-    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@d8b99b2",
+    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@9c97499",
     "@eox/chart": "^1.2.0",
     "@eox/drawtools": "^1.6.0",
     "@eox/elements-utils": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "check": "vue-tsc && eslint ."
   },
   "dependencies": {
-    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@9c97499",
+    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@08af85a",
     "@eox/chart": "^1.2.0",
     "@eox/drawtools": "^1.6.0",
     "@eox/elements-utils": "^1.2.0",
     "@eox/itemfilter": "^1.17.3",
     "@eox/jsonform": "^1.12.1",
-    "@eox/layercontrol": "^1.8.0",
+    "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@7eb12be",
     "@eox/layout": "^1.0.0",
     "@eox/map": "^2.7.0",
     "@eox/storytelling": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -10,26 +10,26 @@
     "check": "vue-tsc && eslint ."
   },
   "dependencies": {
-    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@7e9e987",
-    "@eox/chart": "^1.1.0",
-    "@eox/drawtools": "^1.4.0",
-    "@eox/elements-utils": "^1.1.1",
-    "@eox/itemfilter": "^1.15.0",
-    "@eox/jsonform": "^1.11.0",
-    "@eox/layercontrol": "^1.5.0",
+    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@d8b99b2",
+    "@eox/chart": "^1.2.0",
+    "@eox/drawtools": "^1.6.0",
+    "@eox/elements-utils": "^1.2.0",
+    "@eox/itemfilter": "^1.17.3",
+    "@eox/jsonform": "^1.12.1",
+    "@eox/layercontrol": "^1.8.0",
     "@eox/layout": "^1.0.0",
-    "@eox/map": "^2.4.0",
-    "@eox/storytelling": "^1.11.0",
-    "@eox/timecontrol": "^2.3.0",
+    "@eox/map": "^2.7.0",
+    "@eox/storytelling": "^1.13.0",
+    "@eox/timecontrol": "^2.6.0",
     "chroma-js": "^3.2.0",
     "ol": "10.9.0",
     "stac-js": "^0.1.9"
   },
   "devDependencies": {
-    "@eox/pages-theme-eox": "^1.6.0",
+    "@eox/pages-theme-eox": "^1.9.0",
     "@types/chroma-js": "^3.1.2",
-    "eslint-plugin-vue": "^10.9.0",
+    "eslint-plugin-vue": "^10.9.2",
     "typescript": "^5.9.3",
-    "vue-tsc": "^3.2.8"
+    "vue-tsc": "^3.3.6"
   }
 }

--- a/sentinelexplorer/sentinel-explorer-config.js
+++ b/sentinelexplorer/sentinel-explorer-config.js
@@ -60,20 +60,17 @@ const catalogFilters = [
     type: "range",
     title: "Cloud cover",
     unitLabel: "%",
-    min: 0,
-    max: 100,
     step: 5,
   },
-  { property: "platform", type: "multiselect", title: "Platform" },
+  {
+    property: "platform",
+    type: "multiselect",
+    title: "Platform",
+  },
   {
     property: "sat:orbit_state",
     type: "multiselect",
     title: "Orbit direction",
-  },
-  {
-    property: "sar:polarizations",
-    type: "multiselect",
-    title: "Polarizations",
   },
 ];
 
@@ -81,6 +78,49 @@ const catalogHoverProperties = [
   "datetime",
   "eo:cloud_cover",
   "sat:orbit_state",
+];
+/** @type {NonNullable<import("@eodash/eodash").TEodashStacInfo["properties"]>["featured"]} */
+const stacInfoFeatured = [
+  "id",
+  "processing:software",
+  { key: "assets", filter: (asset) => !!asset },
+  {
+    key: "links",
+    filter: (link) =>
+      link.rel == "self" ||
+      (!!link.title && !["xyz", "tilejson"].includes(link.rel)),
+  },
+];
+
+const sentinel2InfoBody = [
+  "datetime",
+  "platform",
+  "constellation",
+  "instruments",
+  "eo:cloud_cover",
+  "eo:snow_cover",
+  "view:sun_elevation",
+  "view:sun_azimuth",
+  "processing:level",
+  "product:type",
+  "processing:facility",
+  "grid:code",
+];
+
+const sentinel1InfoBody = [
+  "datetime",
+  "platform",
+  "constellation",
+  "instruments",
+  "sat:orbit_state",
+  "sat:relative_orbit",
+  "sar:instrument_mode",
+  "sar:polarizations",
+  "sar:product_type",
+  "sar:frequency_band",
+  "processing:level",
+  "product:type",
+  "processing:facility",
 ];
 
 export default /*** @type {import("@eodash/eodash").Eodash} */ ({
@@ -191,42 +231,25 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
           },
         },
         {
-          id: "StacInfo",
-          type: "internal",
-          title: "Information",
-          layout: { x: "9/9/10", y: 7, w: "3/3/2", h: 4 },
-          widget: {
-            name: "EodashStacInfo",
-            properties: {
-              level: "item",
-              allowHtml: true,
-              header: ["collection"],
-              // tags:["instruments"],
-              body: [
-                "datetime",
-                "platform",
-                "constellation",
-                "instruments",
-                "eo:cloud_cover",
-                "processing:level",
-                "product:type",
-                "eo:snow_cover",
-                "view:sun_elevation",
-                "processing:facility",
-              ],
-              footer: ["providers"],
-              featured: [
-                "id",
-                "processing:software",
-                { key: "assets", filter: (asset) => !!asset },
-                {
-                  key: "links",
-                  filter: (link) =>
-                    link.rel == "self" ||
-                    (!!link.title && !["xyz", "tilejson"].includes(link.rel)),
+          defineWidget: (selectedSTAC) => {
+            const isSentinel1 = selectedSTAC?.id?.includes("sentinel-1");
+            return {
+              id: isSentinel1 ? "StacInfo-s1" : "StacInfo-s2",
+              type: "internal",
+              title: "Information",
+              layout: { x: "9/9/10", y: 7, w: "3/3/2", h: 4 },
+              widget: {
+                name: "EodashStacInfo",
+                properties: {
+                  level: "item",
+                  allowHtml: true,
+                  header: ["collection"],
+                  body: isSentinel1 ? sentinel1InfoBody : sentinel2InfoBody,
+                  footer: ["providers"],
+                  featured: stacInfoFeatured,
                 },
-              ],
-            },
+              },
+            };
           },
         },
         {
@@ -238,7 +261,6 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
             name: "EodashItemCatalog",
             properties: {
               useMosaic: false,
-              mosaicIndicators: ["sentinel-2-l2a"],
               layoutTarget: "mosaic",
               datetimeFilter: true,
               filters: catalogFilters,
@@ -272,9 +294,9 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
           properties: {
             zoomToExtent: false,
             enableCompare: true,
-            btnsPosition: {
-              gap: 8,
-            },
+            // btnsPosition: {
+            //   gap: 8,
+            // },
             btns: {
               enableZoom: true,
               enableExportMap: true,
@@ -343,16 +365,19 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
                   type: "internal",
                   widget: {
                     name: "EodashStacInfo",
-                    body: ["description"],
-                    featured: [
-                      "satellite",
-                      "sensor",
-                      "agency",
-                      "extent",
-                      "providers",
-                      "assets",
-                      "links",
-                    ],
+                    properties: {
+                      level: "collection",
+                      body: ["description"],
+                      featured: [
+                        "satellite",
+                        "sensor",
+                        "agency",
+                        "extent",
+                        "providers",
+                        "assets",
+                        "links",
+                      ],
+                    },
                   },
                 }
               : null;

--- a/sentinelexplorer/sentinel-explorer-config.js
+++ b/sentinelexplorer/sentinel-explorer-config.js
@@ -2,67 +2,87 @@ import { mdiMapSearch } from "@mdi/js";
 
 const baseLayers = [
   {
-    type: "Group",
+    type: "Tile",
+    visible: false,
     properties: {
-      id: "BaseLayersGroup",
-      title: "Base Layers",
+      id: "OSM;:;EPSG:3857",
+      title: "OSM Background",
+      roles: ["baselayer", "invisible"],
+      group: "baselayer",
+      layerControlExclusive: true,
     },
-    layers: [
-      {
-        type: "Tile",
-        properties: {
-          id: "OSM;:;EPSG:3857",
-          title: "OSM Background",
-          roles: ["baselayer", "invisible"],
-          group: "baselayer",
-          visible: false,
-          layerControlExclusive: true,
-        },
-        source: {
-          type: "XYZ",
-          url: "https://{a-e}.s2maps-tiles.eu/wmts/1.0.0/osm_3857/default/g/{z}/{y}/{x}.jpeg",
-          projection: "EPSG:3857",
-        },
-        preload: Infinity,
-      },
-      {
-        type: "Tile",
-        properties: {
-          id: "terrain-light;:;EPSG:3857",
-          title: "Terrain Light",
-          roles: ["baselayer", "visible"],
-          group: "baselayer",
-          visible: true,
-          layerControlExclusive: true,
-        },
-        source: {
-          type: "XYZ",
-          url: "https://{a-e}.s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
-          projection: "EPSG:3857",
-        },
-        preload: Infinity,
-      },
-      {
-        type: "Tile",
-        properties: {
-          id: "cloudless-2024;:;EPSG:3857",
-          title: "EOxCloudless 2024",
-          roles: ["baselayer", "invisible"],
-          group: "baselayer",
-          visible: false,
-          layerControlExclusive: true,
-        },
-        source: {
-          type: "XYZ",
-          url: "https://{a-e}.s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2024_3857/default/g/{z}/{y}/{x}.jpeg",
-          projection: "EPSG:3857",
-        },
-        preload: Infinity,
-      },
-    ],
-    interactions: [],
+    source: {
+      type: "XYZ",
+      url: "https://{a-e}.s2maps-tiles.eu/wmts/1.0.0/osm_3857/default/g/{z}/{y}/{x}.jpeg",
+      projection: "EPSG:3857",
+    },
+    preload: Infinity,
+  },
+  {
+    type: "Tile",
+    properties: {
+      id: "terrain-light;:;EPSG:3857",
+      title: "Terrain Light",
+      roles: ["baselayer", "visible"],
+      group: "baselayer",
+      visible: true,
+      layerControlExclusive: true,
+    },
+    source: {
+      type: "XYZ",
+      url: "https://{a-e}.s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
+      projection: "EPSG:3857",
+    },
+    preload: Infinity,
+  },
+  {
+    type: "Tile",
+    properties: {
+      id: "cloudless-2024;:;EPSG:3857",
+      title: "EOxCloudless 2024",
+      roles: ["baselayer", "invisible"],
+      group: "baselayer",
+      visible: false,
+      layerControlExclusive: true,
+    },
+    source: {
+      type: "XYZ",
+      url: "https://{a-e}.s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2024_3857/default/g/{z}/{y}/{x}.jpeg",
+      projection: "EPSG:3857",
+    },
+    preload: Infinity,
   },
 ];
+
+const catalogFilters = [
+  {
+    property: "eo:cloud_cover",
+    type: "range",
+    title: "Cloud cover",
+    unitLabel: "%",
+    min: 0,
+    max: 100,
+    step: 5,
+  },
+  { property: "platform", type: "multiselect", title: "Platform" },
+  {
+    property: "sat:orbit_state",
+    type: "multiselect",
+    title: "Orbit direction",
+  },
+  {
+    property: "sar:polarizations",
+    type: "multiselect",
+    title: "Polarizations",
+  },
+];
+
+const catalogHoverProperties = [
+  "datetime",
+  "eo:cloud_cover",
+  "sat:orbit_state",
+];
+
 export default /*** @type {import("@eodash/eodash").Eodash} */ ({
   id: "eopf",
   options: {
@@ -82,6 +102,8 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
     endpoint: "https://api.explorer.eopf.copernicus.eu/stac",
     api: true,
     rasterEndpoint: "https://api.explorer.eopf.copernicus.eu/raster",
+    colormapRegistry:
+      "https://raw.githubusercontent.com/eurodatacube/eodash-assets/refs/heads/main/defaults/colormaps.json",
     supportedUpscalingEndpoints: [
       { url: "api.explorer.eopf.copernicus.eu/raster/", titilerVersion: 2 },
     ],
@@ -218,7 +240,9 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
               useMosaic: false,
               mosaicIndicators: ["sentinel-2-l2a"],
               layoutTarget: "mosaic",
-              hoverProperties: ["datetime", "eo:cloud_cover"],
+              datetimeFilter: true,
+              filters: catalogFilters,
+              hoverProperties: catalogHoverProperties,
             },
           },
         },
@@ -345,6 +369,7 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
                   widget: {
                     name: "EodashTimeSlider",
                     properties: {
+                      clustering: true,
                       style: "padding:12px",
                       animate: true,
                       useMosaic: true,
@@ -425,6 +450,9 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
             name: "EodashItemCatalog",
             properties: {
               layoutTarget: "mosaic",
+              datetimeFilter: true,
+              filters: catalogFilters,
+              hoverProperties: catalogHoverProperties,
             },
           },
         },
@@ -438,6 +466,9 @@ export default /*** @type {import("@eodash/eodash").Eodash} */ ({
             properties: {
               enableCompare: true,
               layoutTarget: "mosaic",
+              datetimeFilter: true,
+              filters: catalogFilters,
+              hoverProperties: catalogHoverProperties,
             },
           },
         },


### PR DESCRIPTION
## Sentinel-1 support

The Item Catalog now switches the filters dynamically based on the selected collection, listing s1 specifc filters instead of s2 properties only by default. Hover properties cover both missions as well. The nav item and the landing page Explorer link no longer pin `indicator=sentinel-2-l2a`, so the Explorer opens on the full collection list.

## eodash upgrade

Pinned to a pkg.pr.new build of eodash carrying, among others:

- refactored rasterform handling and dynamic visualization support
-  persisted rasterform state 
- Added `${}` templating in EodashStyle and Rasterform to support EOPF-Explorer/data-pipeline#348
- reworked bands editor UI
- "item" URL search parameter support 
- Item Catalog props and filters adapting to the selected collection
- TileJSON raster layer support


## STAC deep links

Item URLs from the STAC catalogue now open the Explorer with the item selected:

    /collections/sentinel-2-l2a/items/S2B_MSIL2A_..._T37UCA_...
    -> /sentinelexplorer/?indicator=sentinel-2-l2a&item=S2B_MSIL2A_..._T37UCA_...

