### PR TITLE
 fix: resolve example STAC items at build time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,27 +8,26 @@
       "name": "eopf-explorer-landing-page",
       "version": "2.0.0",
       "dependencies": {
-        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@08af85a",
+        "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@4b0a4d8",
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
         "@eox/elements-utils": "^1.2.0",
-        "@eox/itemfilter": "^1.17.3",
-        "@eox/jsonform": "^1.12.1",
-        "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@7eb12be",
+        "@eox/itemfilter": "^1.17.5",
+        "@eox/jsonform": "^1.12.2",
+        "@eox/layercontrol": "^1.8.2",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "^2.7.0",
+        "@eox/map": "^2.7.2",
         "@eox/storytelling": "^1.13.0",
         "@eox/timecontrol": "^2.6.0",
         "chroma-js": "^3.2.0",
-        "ol": "10.9.0",
-        "stac-js": "^0.1.9"
+        "ol": "10.10.0"
       },
       "devDependencies": {
         "@eox/pages-theme-eox": "^1.9.0",
         "@types/chroma-js": "^3.1.2",
-        "eslint-plugin-vue": "^10.9.2",
-        "typescript": "^5.9.3",
-        "vue-tsc": "^3.3.6"
+        "eslint-plugin-vue": "^10.10.0",
+        "typescript": "^6.0.2",
+        "vue-tsc": "^3.3.10"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -290,51 +289,35 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
-    },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
@@ -355,12 +338,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -369,19 +352,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -404,9 +378,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
       "funding": [
         {
           "type": "github",
@@ -423,9 +397,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "funding": [
         {
           "type": "github",
@@ -446,9 +420,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
       "funding": [
         {
           "type": "github",
@@ -461,8 +435,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -495,9 +469,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
       "funding": [
         {
           "type": "github",
@@ -602,46 +576,43 @@
       }
     },
     "node_modules/@eodash/eodash": {
-      "version": "5.8.0",
-      "resolved": "https://pkg.pr.new/@eodash/eodash@08af85a",
-      "integrity": "sha512-0Vp9U2aEGVxjpBmbcJC83T6MbVIzz0GBEoDMolvp9oH4thuJD3WhHgI7CJjdZhoucRDXLC5Luf5ai2mI438YVQ==",
+      "version": "5.9.0",
+      "resolved": "https://pkg.pr.new/@eodash/eodash@4b0a4d8",
+      "integrity": "sha512-zXg7fuiDba+cQYgVD2aFfTAvM/HN+ExCwC32t9xmQS3aASH2/Sp4tPcmYJ7vG+8AYimtDflMivrSUntFa0zSsg==",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
         "@eox/feedback": "^1.2.0",
         "@eox/geosearch": "^1.2.0",
-        "@eox/itemfilter": "^1.17.3",
-        "@eox/jsonform": "^1.12.1",
-        "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@bbc3b0b",
+        "@eox/itemfilter": "^1.17.5",
+        "@eox/jsonform": "^1.12.2",
+        "@eox/layercontrol": "^1.8.2",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "^2.7.0",
+        "@eox/map": "^2.7.2",
         "@eox/stacinfo": "^1.2.0",
         "@eox/timecontrol": "^2.6.0",
         "@eox/ui": "^1.1.0",
         "@mdi/js": "^7.4.47",
-        "@vitejs/plugin-vue": "^6.0.7",
-        "@vueuse/core": "^14.3.0",
+        "@vitejs/plugin-vue": "^6.0.8",
+        "@vueuse/core": "^14.4.0",
         "animated-details": "gist:2912bb049fa906671807415eb0e87188",
-        "axios": "^1.17.0",
-        "axios-cache-interceptor": "^1.12.0",
+        "axios": "^1.19.0",
+        "axios-cache-interceptor": "^1.12.3",
         "color-legend-element": "^1.5.0",
-        "commander": "^14.0.3",
-        "core-js": "^3.49.0",
-        "dotenv": "^17.4.2",
-        "hyparquet": "^1.26.0",
+        "commander": "^15.0.0",
+        "hyparquet": "^1.27.1",
         "loglevel": "^1.9.2",
         "mustache": "^4.2.0",
-        "pinia": "^3.0.4",
-        "proj4": "^2.20.8",
-        "sass": "^1.100.0",
+        "pinia": "^4.0.2",
+        "sass": "^1.102.0",
         "stac-js": "^0.4.3",
         "stac-ts": "^1.0.5",
-        "v-calendar": "3.0.0",
-        "vega-embed": "^6.29.0",
-        "vega-lite": "^5.23.0",
-        "vite": "^7.3.5",
+        "vite": "^8.2.0",
         "vite-plugin-vuetify": "^2.1.3",
-        "vue": "^3.5.35",
+        "vue": "^3.5.41",
         "vuetify": "^3.12.8",
         "webfontloader": "^1.6.28"
       },
@@ -649,30 +620,69 @@
         "eodash": "dist/node/cli.js"
       },
       "engines": {
-        "node": ">=20.15.1"
+        "node": ">=24.0.0"
       }
     },
-    "node_modules/@eodash/eodash/node_modules/@eox/layercontrol": {
-      "version": "1.8.2",
-      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@bbc3b0b",
-      "integrity": "sha512-D3bsz5m9U8oD7E62In1sBv665/pXbrdvpbDkhBle6tP3LyOFVoZLFYinQ6bYuKEjFGDQ5l4hl+uR5jrZQwhWDA==",
+    "node_modules/@eodash/eodash/node_modules/@vue/devtools-api": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+      "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@eox/elements-utils": "^1.2.0",
-        "@eox/ui": "^1.1.0",
-        "color-legend-element": "^1.5.0",
-        "lit": "^3.3.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "sortablejs": "^1.15.0",
-        "wms-capabilities": "^0.6.0"
+        "@vue/devtools-kit": "^8.2.1"
+      }
+    },
+    "node_modules/@eodash/eodash/node_modules/@vue/devtools-kit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+      "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-shared": "^8.2.1",
+        "birpc": "^2.6.1",
+        "hookable": "^5.5.3",
+        "perfect-debounce": "^2.0.0"
+      }
+    },
+    "node_modules/@eodash/eodash/node_modules/@vue/devtools-shared": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+      "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@eodash/eodash/node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@eodash/eodash/node_modules/pinia": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.3.tgz",
+      "integrity": "sha512-XMQqpvjgG7LMqVhhFUzKLT4KEbsYbfZZ0CZU9PgdFm1O2VKBmIkykL8+SfNhOaT7sR0wT6BEgKT0YNDYWgmVRA==",
+      "license": "MIT",
+      "dependencies": {
+        "nostics": "^1.1.4"
       },
-      "engines": {
-        "node": ">=24.0.0",
-        "npm": ">=8.0.0"
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "@eox/jsonform": "*",
-        "@eox/timecontrol": ">=2.0.0"
+        "@vue/devtools-api": "^8.1.5",
+        "typescript": ">=5.6.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "@vue/devtools-api": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eodash/eodash/node_modules/stac-js": {
@@ -1656,17 +1666,17 @@
       }
     },
     "node_modules/@eox/itemfilter": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@eox/itemfilter/-/itemfilter-1.17.3.tgz",
-      "integrity": "sha512-SBJBL6QBgbPy66+NS7TGVCbAmXrXRcVIMrUFbJimIPurMKpRSVlTqljGd27YknxB+w55V/qR4hbEmJQM1oJ6cQ==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@eox/itemfilter/-/itemfilter-1.17.5.tgz",
+      "integrity": "sha512-+YLyoIilS0nQTd4aI/+BIc2scvOX/aYNa6TZF0jPR4VO5MxuPW1ZvkFnN2YIcagmjBkHbSFjop2YJdOjQ9Ifow==",
       "dependencies": {
-        "@eox/elements-utils": "^1.1.0",
+        "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
         "@floating-ui/dom": "^1.6.8",
         "@turf/boolean-intersects": "^7.3.5",
         "@turf/boolean-within": "^7.3.5",
-        "dayjs": "^1.11.9",
-        "fuse.js": "^7.3.0",
+        "dayjs": "^1.11.21",
+        "fuse.js": "^7.4.2",
         "lit": "^3.3.3",
         "lodash.debounce": "^4.0.8",
         "lodash.flatmap": "^4.5.0",
@@ -1684,17 +1694,17 @@
       }
     },
     "node_modules/@eox/jsonform": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@eox/jsonform/-/jsonform-1.12.1.tgz",
-      "integrity": "sha512-Obykhbjjyxwva2drfjKqLXPLCrx7MOuAIcjE6errnJCcE3dTP4LQ0haTNxL+0tnBlmv1o+tX8nREzefNOPKG8A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@eox/jsonform/-/jsonform-1.12.2.tgz",
+      "integrity": "sha512-CQAe7QSLJLVqvy6/CcHucFDGwQGu4/PdMvEdMxa6w5j/i9LqIvGA60Bd+3SjxBeXoitGpwCt5dV9W15JbseMqg==",
       "dependencies": {
-        "@eox/elements-utils": "^1.1.0",
+        "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
-        "@json-editor/json-editor": "^2.16.0",
+        "@json-editor/json-editor": "^2.17.1",
         "@turf/bbox-polygon": "^7.3.5",
         "ace-builds": "^1.44.0",
         "easymde": "^2.21.0",
-        "isomorphic-dompurify": "^3.13.0",
+        "isomorphic-dompurify": "^3.18.0",
         "lit": "^3.3.3",
         "lodash.isequal": "^4.5.0",
         "toolcool-range-slider": "^4.0.28"
@@ -1705,9 +1715,9 @@
       }
     },
     "node_modules/@eox/layercontrol": {
-      "version": "1.8.0",
-      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@7eb12be",
-      "integrity": "sha512-6HgDfkhM8lxPcsYpk59kqLZz+y7PdsYMqfzlqH8YtgWwFC7KgDG2sgwVSWnbobKd9uJzvkAFaFtz4XoT48j9sg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@eox/layercontrol/-/layercontrol-1.8.2.tgz",
+      "integrity": "sha512-BOsUPgKJrODz/hh+ftYY+S0L8X6cFUgzQ8g170VzEk5tS+uQhzALkxl/4viEwKq0/q8PzYRE5CcNK/e8w9Gtqw==",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
@@ -1733,9 +1743,9 @@
       "integrity": "sha512-+n5Ym18Bq9l6isyK0DexMrba/eD0uPhqLgtS2BPrFHyEQ0m/T8n3nTDl/wu7zI9V3Vf9mw9KurhrD/oJGth5gw=="
     },
     "node_modules/@eox/map": {
-      "version": "2.7.0",
-      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
-      "integrity": "sha512-7jKOx/AgFwqTmFN7lYMxQKh48CUdQ34q4FI+CjVWwij6Czbn1vrE4LyPM4+coXvuwdPTTpxR4uFQzAamou8uYA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@eox/map/-/map-2.7.2.tgz",
+      "integrity": "sha512-inOuliBwfkeooTY4YGsmtAUi7y5IqWzomqPdMjDih6AEf/duo/mtCOIgTUnmu5wf3EXaXEKQpthFaSjbmJN+AA==",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",
@@ -1744,7 +1754,7 @@
         "lit": "^3.3.3",
         "ol": "^10.9.0",
         "ol-mapbox-style": "^13.4.1",
-        "ol-stac": "^1.4.0",
+        "ol-stac": "^1.5.1",
         "proj4": "^2.20.9",
         "serialize-javascript": "^7.0.1"
       },
@@ -1843,422 +1853,6 @@
       "license": "MIT",
       "dependencies": {
         "beercss": "4.0.16"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2486,9 +2080,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -2695,9 +2289,9 @@
       "license": "MIT"
     },
     "node_modules/@json-editor/json-editor": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@json-editor/json-editor/-/json-editor-2.16.0.tgz",
-      "integrity": "sha512-qzCDDImLAkqCpOp3G156ikEHTJKQviVyxie+3QXE1MTxRuT+BZ3yTYsXfUpvgRyaLBcYDJIind59Hj3oz+5TqA==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@json-editor/json-editor/-/json-editor-2.17.1.tgz",
+      "integrity": "sha512-CXxgl36nMmiuJHNPy+r4mGfF9zw/cuXlDFnANMpPW0XFQXz979OhmsEninxXUZymdyleYQ+PTZa+ePkES1CJfA==",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.27.2"
@@ -2784,6 +2378,15 @@
       "resolved": "https://registry.npmjs.org/@openglobus/og/-/og-0.28.7.tgz",
       "integrity": "sha512-+0g0dJIdKGhF/wfAWEAFvJfSV/1Pt6iB73Y4wsNzchajZj2Wjcc+RwiycWO99adjgALoUMjAASp2FIrKMu204g==",
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
@@ -3105,17 +2708,6 @@
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
       "license": "MIT"
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@radiantearth/stac-fields": {
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.5.9.tgz",
@@ -3133,13 +2725,12 @@
       }
     },
     "node_modules/@radiantearth/stac-migrate": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@radiantearth/stac-migrate/-/stac-migrate-2.0.2.tgz",
-      "integrity": "sha512-1GsszCVwZY42tQCOnhLzOERnXXzJBX5PQ5Qq1puBI19liWzdJZO2+6bbKmQclkYsPJYiQ6JnLbGf5QWIw4S+kQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radiantearth/stac-migrate/-/stac-migrate-2.1.0.tgz",
+      "integrity": "sha512-AlRzYnpf5BbglJ/MQMsgmhM9cDpnThBjH8i7LICeXJVd2a5uhEhfrPMvMeAAPQVq/TpVo6UlaqYJxTst3CM5dg==",
       "license": "Apache-2.0",
       "dependencies": {
         "compare-versions": "^3.6.0",
-        "multihashes": "^3.1.2",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -3156,6 +2747,264 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
@@ -3169,6 +3018,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3182,6 +3032,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3195,6 +3046,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3208,6 +3060,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,6 +3074,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3234,6 +3088,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3247,6 +3102,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3263,6 +3119,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3279,6 +3136,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3295,6 +3153,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3311,6 +3170,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3327,6 +3187,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3343,6 +3204,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3359,6 +3221,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3375,6 +3238,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3391,6 +3255,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3407,6 +3272,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3423,6 +3289,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3439,6 +3306,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3455,6 +3323,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3468,6 +3337,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3481,6 +3351,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3494,6 +3365,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3507,6 +3379,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3520,6 +3393,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3676,6 +3550,284 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.4.0.tgz",
+      "integrity": "sha512-3wO+W9P63JZMK1Ud5ER0kKXpiZaeXkOR5Omq5USKlPcopwZ6TP/mJjt8lUYYWsB2WGDXuUhlYmSVec43z3wwow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise/node_modules/@turf/helpers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise/node_modules/@turf/invariant": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.4.0.tgz",
+      "integrity": "sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.4.0.tgz",
+      "integrity": "sha512-vR8sfdKhSlDy6Jd6UAI2Bt27ZAU287G8lhLieIGfxKCpoUa2V8v3y0I9FH+ZpFen07I33aysHIZ4dMH92hBO3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.4.0",
+        "@turf/boolean-point-in-polygon": "7.4.0",
+        "@turf/boolean-point-on-line": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/line-split": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/bbox": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.4.0.tgz",
+      "integrity": "sha512-yOX9lALc2GmjYUIE99+nRj7eZA7eDtx7Ixu/hrgIo+YqHvL1reaPVTC9rQWMHMm0pH0/WHjzk8uOpAHjptrudQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.4.0.tgz",
+      "integrity": "sha512-GQrHc6WSDHhf32GB/b9AGyOeC05AQ3nGN7ooWTrlCYefKn7X9/2wG9BNexF47AuyDq5jPdOvITVR26BLFWV+mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/boolean-point-on-line": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.4.0.tgz",
+      "integrity": "sha512-5i5UBeZf/LuzgavkIj8L8L5/8SYWItWzQQcE9ymFZr60lV5lM8eFvQDfzAz2R3WQFCrxXExPqNvAVZOKGUyvoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/distance": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.4.0.tgz",
+      "integrity": "sha512-ODkopQDG1m/U6Mx7OMmShncaCvneomwX3lZY1CDA7x40bhDdTTRYP/n/6LicZVyIO4/oK+aXkov4NOtWYthA2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/geojson-rbush": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.4.0.tgz",
+      "integrity": "sha512-o+debVj+6KQ2p0VebH+FgcTig2jUuG6mWMgLYvb34c7cOHoEuY6ICvKRKtHn/XcHa6eyoSk0TvnLEJAfFTQDMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/helpers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/invariant": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.4.0.tgz",
+      "integrity": "sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/line-intersect": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.4.0.tgz",
+      "integrity": "sha512-5qNmEJ/0tQEaUUKSt2zIZGIS6eYGn3T7Z32yN6+Py0ANs8ln3dQNWaDyOEMms/qVY7BFvSaO+8iBmD8vlHdNcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/line-segment": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.4.0.tgz",
+      "integrity": "sha512-v4Gnxpj6XqWbl4d/aVZHYwvSFzaTGGBW4eQQ9Ozqcgt+bvignOMdtVogFDHSWKDj9Gr2tbS2jYp57c8OTa+Olw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/line-split": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.4.0.tgz",
+      "integrity": "sha512-bAij7u19sFVdYoAp3bQnu/cVzlORxM/W3FM+WeFN/VvGkZ6YiAtcPq/lLP4WwK3WxthTcavED3wbd32iXGpzZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.4.0",
+        "@turf/geojson-rbush": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/line-intersect": "7.4.0",
+        "@turf/line-segment": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@turf/nearest-point-on-line": "7.4.0",
+        "@turf/truncate": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/meta": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.4.0.tgz",
+      "integrity": "sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/nearest-point-on-line": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.4.0.tgz",
+      "integrity": "sha512-eKTKf/qODIsPankYMZrNfI3LjLaVtQvYV/1hcj9kH/Zr3GfLUszevjhTRDZtMgTFrv8+awW3+MyhmN+PJGuLdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/@turf/truncate": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.4.0.tgz",
+      "integrity": "sha512-eTXO62l1mD++mKlhUqLNHGcgCQvhxXJGB/EUL1KSzpVIeMYtgcmItAneWdHW+gEpmHfjeDjBuvtbZWA23r7Eig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
+    },
+    "node_modules/@turf/boolean-contains/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/@turf/boolean-disjoint": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.5.tgz",
@@ -3753,6 +3905,75 @@
         "@turf/helpers": "7.3.5",
         "@turf/invariant": "7.3.5",
         "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.4.0.tgz",
+      "integrity": "sha512-WglCFe+TnMqeYa/LcbUp37NgIF0zHTNYmlxwUm40fyyzyLsYeDq4dgFWLTYpvRNqb5oIMV6xsBjSf+vCPtVJ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid/node_modules/@turf/helpers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid/node_modules/@turf/meta": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.4.0.tgz",
+      "integrity": "sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.4.0.tgz",
+      "integrity": "sha512-IfYnuil7XYJauy3crzIYEr26QkmBiTgFdGfYwUUe3S6dawX+lyb3vhuaYyssEPcCJq83g0G7hwxZy7141Mmzjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone/node_modules/@turf/helpers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
+      "license": "MIT",
+      "dependencies": {
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -3918,6 +4139,65 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/rewind": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.4.0.tgz",
+      "integrity": "sha512-Q2qOcLzymxXyIAYXM9BZQT09L63EhzgneCBMka0dPf9jVShxMeA3oF1kY20ChWkZvTGOAbM7YU9hghphbCxo2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.4.0",
+        "@turf/clone": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/helpers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/invariant": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.4.0.tgz",
+      "integrity": "sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/meta": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.4.0.tgz",
+      "integrity": "sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/truncate": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
@@ -4000,12 +4280,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
@@ -4044,12 +4318,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
       "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz",
-      "integrity": "sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==",
       "license": "MIT"
     },
     "node_modules/@types/tern": {
@@ -4318,9 +4586,9 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
-      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
       "license": "MIT",
       "dependencies": {
         "@rolldown/pluginutils": "^1.0.1"
@@ -4363,13 +4631,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
-      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.38",
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -4388,46 +4656,47 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
-      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
-      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.5.38",
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/compiler-ssr": "3.5.38",
-        "@vue/shared": "3.5.38",
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
-      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/devtools-api": {
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
       "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-kit": "^7.7.9"
@@ -4437,6 +4706,7 @@
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
       "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-shared": "^7.7.9",
@@ -4452,75 +4722,74 @@
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
       "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rfdc": "^1.4.1"
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.6.tgz",
-      "integrity": "sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.10.tgz",
+      "integrity": "sha512-CR7ByBbgPHqhxrioKPOcZBqttaozzLNwtkCzXQ+uF8gLPHnUe03srPnGpdtHD3zp+bq5iyVkZ1WNx7W564RPwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.2.0",
+        "alien-signals": "^3.2.1",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
         "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
-      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.38"
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
-      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
-      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.38",
-        "@vue/runtime-core": "3.5.38",
-        "@vue/shared": "3.5.38",
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
-      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.38",
-        "@vue/shared": "3.5.38"
-      },
-      "peerDependencies": {
-        "vue": "3.5.38"
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
-      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "license": "MIT"
     },
     "node_modules/@vuetify/loader-shared": {
@@ -4537,14 +4806,14 @@
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
-      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+      "integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "14.3.0",
-        "@vueuse/shared": "14.3.0"
+        "@vueuse/metadata": "14.4.0",
+        "@vueuse/shared": "14.4.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -4660,18 +4929,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
-      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+      "integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
-      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+      "integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -4844,21 +5113,21 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-cache-interceptor": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.12.0.tgz",
-      "integrity": "sha512-15XuJkdeJmQo/HY2b0xx3zim8DMx7Nu+G8R4z6OG2VZLtbIDnsfn4qZsLLvkPfK4SVNRzXnoG4jPR7dqdQznRA==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.12.3.tgz",
+      "integrity": "sha512-IK8+YGxH03wOImvVg1PlujxZ9CoBsUpqv2TdGlgENeo9wcL63N6usYW0glmK3mNrfu+CPA/lWeSuo0+9OmNJrw==",
       "license": "MIT",
       "dependencies": {
         "cache-parser": "^1.2.6",
@@ -4874,7 +5143,7 @@
         "url": "https://github.com/arthurfiorette/axios-cache-interceptor?sponsor=1"
       },
       "peerDependencies": {
-        "axios": "^1"
+        "axios": "^1.19.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5158,12 +5427,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/commonmark": {
@@ -5220,6 +5489,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
       "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-what": "^5.2.0"
@@ -5563,29 +5833,18 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.21.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
-      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -5683,7 +5942,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5703,24 +5961,12 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -5818,47 +6064,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -5995,18 +6200,18 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz",
-      "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
+      "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^7.1.0",
-        "semver": "^7.6.3",
-        "xml-name-validator": "^4.0.0"
+        "postcss-selector-parser": "^7.1.4",
+        "semver": "^7.8.5",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6317,16 +6522,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6356,9 +6561,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
-      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+      "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
@@ -6378,9 +6583,9 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
-      "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
+      "version": "3.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.1.0-beta.0.tgz",
+      "integrity": "sha512-wbVwOaQYuN+ywly5NoMXn37nHslwkQg5EFHqMeUTtjDACrSag0EEVlFsc+2DK3Pzmmp6XzJW2RTZOamPsBM6ng==",
       "license": "MIT",
       "dependencies": {
         "@petamoriken/float16": "^3.9.3",
@@ -6554,9 +6759,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6652,9 +6857,9 @@
       }
     },
     "node_modules/hyparquet": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.26.0.tgz",
-      "integrity": "sha512-yxUiViPZ+z5h+xdX4rA1G+k30jXoEsG9I2xEpjaM84imGznbKjZzxuZFsdzqg6C4LxNnnAlDFvzpk4uxQWTbTQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.29.1.tgz",
+      "integrity": "sha512-Wa57A2KxGFtRTeDTJp4pT0TaqN8btb7/XTrMs17iM+xJxsbBxRyzaGaRRPQ4lOPbmso/qohDafJD7b+cFMZq8A==",
       "license": "MIT"
     },
     "node_modules/iconv-lite": {
@@ -6849,6 +7054,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
       "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6865,16 +7071,16 @@
       "license": "ISC"
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.17.0.tgz",
-      "integrity": "sha512-++PY22SYWZv/kTWOr5WQ8rNznkIKj6I/SDUVZnXXM67EhRO7ScVLDdZYNxNgEsPAOA5sfpGBcqnnbLx8WJHO1g==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.22.0.tgz",
+      "integrity": "sha512-cz/BkSODnQir4IV2quqbuEHhAGz4MAYGvhoemsxuwMpY/oZbRHlNjPLPyIQ0fdULiwDPUE+OHPwWb6XTEiNk1A==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.4.10",
-        "jsdom": "^29.1.1"
+        "dompurify": "^3.4.12",
+        "jsdom": "^30.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/joi": {
@@ -6918,52 +7124,43 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
+        "lru-cache": "^11.5.2",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "whatwg-url": "^17.1.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "canvas": "^3.2.3"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/json-buffer": {
@@ -7030,6 +7227,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -7090,6 +7548,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -7168,9 +7627,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -7463,6 +7922,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/moment": {
@@ -7534,9 +7994,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -7565,51 +8025,11 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+    "node_modules/nostics": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
+      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
+      "license": "MIT"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -7640,15 +8060,15 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-10.9.0.tgz",
-      "integrity": "sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.10.0.tgz",
+      "integrity": "sha512-tLPKn6zl+6uWdPufYlqG/lQzuVUTVmfwahQqVr5+wZNyZecyAtIhMTyOtKpu7ooNDLY2sEjKZNXw9HL+sOjC1A==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
-        "geotiff": "^3.0.5 || ^3.1.0-beta.0",
-        "pbf": "4.0.1",
+        "geotiff": "^3.1.0-beta.0",
+        "pbf": "5.1.2",
         "rbush": "^4.0.0",
         "zarrita": "^0.7.1"
       },
@@ -7686,14 +8106,15 @@
       }
     },
     "node_modules/ol-stac": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ol-stac/-/ol-stac-1.4.0.tgz",
-      "integrity": "sha512-LZEpZtZmnptcL83X8X3RhPyra3iHmBbThCpgypqpFWC2VR/QEvH847PpHoC4QqE8pVzGFHxjB9nOGrFbyPeINw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ol-stac/-/ol-stac-1.6.0.tgz",
+      "integrity": "sha512-74Pis7oCy3o2t2cGxFS+Gg+pRMPx3aPnVh1kHdUUCFUPBuWYi1dwfjcdKE2Gu5JXZTC7QOlQ84PqOedn9enPDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ol-pmtiles": "^2.0.0",
         "proj4": "^2.16.1",
-        "stac-js": "^0.4.2"
+        "stac-js": "^0.5.5",
+        "zarrita": "^0.7.3"
       },
       "funding": {
         "type": "github",
@@ -7701,20 +8122,6 @@
       },
       "peerDependencies": {
         "ol": ">=9.0.0"
-      }
-    },
-    "node_modules/ol-stac/node_modules/stac-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/stac-js/-/stac-js-0.4.3.tgz",
-      "integrity": "sha512-OQZEhfj3RlESEWa5GqXd9CtSzNsTqmVljcGvhUqXzTe/WwxpzwGkCFHZJpYnuCLtYh01Yv8Ba/RjiK/O+6pj/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@radiantearth/stac-migrate": "^2.0.2",
-        "urijs": "^1.19.11"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/m-mohr"
       }
     },
     "node_modules/ol/node_modules/rbush": {
@@ -7865,9 +8272,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -7880,6 +8287,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7889,9 +8297,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7900,31 +8308,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pinia": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
-      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-api": "^7.7.7"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/posva"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.5.0",
-        "vue": "^3.5.11"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/pmtiles": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.1.tgz",
-      "integrity": "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.5.0.tgz",
+      "integrity": "sha512-CBeD4SoUluFziGdy/8k7FOjQxQy486n+929W/tWophauvMICpkZ26vGBWhDt/6b1FZQWNaf4jFdT/5+q0Wii5w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -7949,9 +8336,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7968,7 +8355,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7977,9 +8364,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8228,6 +8615,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/robust-predicates": {
@@ -8236,10 +8624,44 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
+    "node_modules/rolldown": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.146.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -8310,9 +8732,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
-      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
+      "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -8350,9 +8772,9 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8463,18 +8885,24 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/stac-js": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/stac-js/-/stac-js-0.1.9.tgz",
-      "integrity": "sha512-qxb8aWQ1T8jJVLsUszpvj9+KrPTDdf2s0bWBWTP+SaplNxznKXXo5xkEPtrXEYwOTbLLeUVSNQhz9J5uFcz6TA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/stac-js/-/stac-js-0.5.5.tgz",
+      "integrity": "sha512-IZi6j3rNDGIjuKRt5DEcm7J6KtK6Q2BkuLR7VdEtOgW2TKvFDI/uiv57RLCB6ckjVw3bnoM+/cN3zVq0LD1X9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@radiantearth/stac-migrate": "^2.0.2",
+        "@radiantearth/stac-migrate": "^2.1.0",
+        "@turf/boolean-clockwise": "^7.2.0",
+        "@turf/boolean-contains": "^7.2.0",
+        "@turf/centroid": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/rewind": "^7.2.0",
         "urijs": "^1.19.11"
       },
       "funding": {
@@ -8551,6 +8979,7 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
       "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "copy-anything": "^4"
@@ -8601,9 +9030,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8623,21 +9052,21 @@
       "license": "ISC"
     },
     "node_modules/tldts": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.30"
+        "tldts-core": "^7.4.10"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "license": "MIT"
     },
     "node_modules/toolcool-range-slider": {
@@ -8667,9 +9096,9 @@
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -8756,9 +9185,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8815,12 +9244,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/unist-util-is": {
@@ -8964,24 +9393,6 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
-    "node_modules/v-calendar": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-3.0.0.tgz",
-      "integrity": "sha512-9r+swG8v2iUvaa2P1BGWEEeutZ+XCttHOzl0uXmzA7JND86GGZbM4QDPm8ZpBXav+NgheRm9MYs/Uz8mgKVZXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "^4.14.165",
-        "@types/resize-observer-browser": "^0.1.7",
-        "date-fns": "^2.16.1",
-        "date-fns-tz": "^1.0.12",
-        "lodash": "^4.17.20",
-        "vue-screen-utils": "^1.0.0-beta.13"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "vue": "^3.2.0"
-      }
-    },
     "node_modules/vanilla-calendar-pro": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vanilla-calendar-pro/-/vanilla-calendar-pro-3.1.0.tgz",
@@ -8997,508 +9408,6 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "license": "MIT"
-    },
-    "node_modules/vega": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.1.tgz",
-      "integrity": "sha512-1fArfVDUqVbb5z8n+/nVQb+VNBzx8svY6CrsyTK4Ujm4yrd9I1auoKxBAPXLCavY1LcrbHUskQbGUP8gXOzyQw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-crossfilter": "~4.1.4",
-        "vega-dataflow": "~5.7.8",
-        "vega-encode": "~4.10.3",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.2.1",
-        "vega-force": "~4.2.3",
-        "vega-format": "~1.1.4",
-        "vega-functions": "~5.18.1",
-        "vega-geo": "~4.4.4",
-        "vega-hierarchy": "~4.1.4",
-        "vega-label": "~1.3.2",
-        "vega-loader": "~4.5.4",
-        "vega-parser": "~6.6.1",
-        "vega-projection": "~1.6.3",
-        "vega-regression": "~1.3.2",
-        "vega-runtime": "~6.2.2",
-        "vega-scale": "~7.4.3",
-        "vega-scenegraph": "~4.13.2",
-        "vega-statistics": "~1.9.0",
-        "vega-time": "~2.1.4",
-        "vega-transforms": "~4.12.2",
-        "vega-typings": "~1.5.1",
-        "vega-util": "~1.17.4",
-        "vega-view": "~5.16.1",
-        "vega-view-transforms": "~4.6.2",
-        "vega-voronoi": "~4.2.5",
-        "vega-wordcloud": "~4.1.7"
-      }
-    },
-    "node_modules/vega-canvas": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
-      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/vega-crossfilter": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.4.tgz",
-      "integrity": "sha512-5E/i60Y80CUt+4O+U89X8ZnauaFuq0ztq/Hx4i4sT/crk4Lfn1oplRAjNOo7dFEZ04TahyBbYiJKIhR0yvmHpw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-dataflow": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.8.tgz",
-      "integrity": "sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-format": "^1.1.4",
-        "vega-loader": "^4.5.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-embed": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.29.0.tgz",
-      "integrity": "sha512-PmlshTLtLFLgWtF/b23T1OwX53AugJ9RZ3qPE2c01VFAbgt3/GSNI/etzA/GzdrkceXFma+FDHNXUppKuM0U6Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "fast-json-patch": "^3.1.1",
-        "json-stringify-pretty-compact": "^4.0.0",
-        "semver": "^7.6.3",
-        "tslib": "^2.8.1",
-        "vega-interpreter": "^1.0.5",
-        "vega-schema-url-parser": "^2.2.0",
-        "vega-themes": "^2.15.0",
-        "vega-tooltip": "^0.35.2"
-      },
-      "peerDependencies": {
-        "vega": "^5.21.0",
-        "vega-lite": "*"
-      }
-    },
-    "node_modules/vega-encode": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.3.tgz",
-      "integrity": "sha512-245ebBuN1TjwVVDFG7JZaZ/ExLAhZ4kDTK2zlIoXs/g2P5rRgL4Q6oRixr+Pgr43G7ISCEHrUBgUjRcSoG8eEA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-event-selector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
-      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-force": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.3.tgz",
-      "integrity": "sha512-7Yp1uOPy3eyzK/hnAIU0v/yQ9mIhtoJ+tq8AMaZiWqy67SUYsE3olmgdllY6R9M81D/n/rv8K+8JjbHMU5/sUA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-format": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.4.tgz",
-      "integrity": "sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-format": "^3.1.0",
-        "d3-time-format": "^4.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-functions": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.1.tgz",
-      "integrity": "sha512-qEBAbo0jxGGebRvbX1zmxzmjwFz8/UtncRhzwk9/KcI0WudULNmCM1iTu+DGFRnNHdcKi6kUlwJBPIp7zDu3HQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-expression": "^5.2.1",
-        "vega-scale": "^7.4.3",
-        "vega-scenegraph": "^4.13.2",
-        "vega-selections": "^5.6.1",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-geo": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.4.tgz",
-      "integrity": "sha512-jTLYrDvhXJinWQCfuVLP1nSlOdFlA9blVS6K7uOcBTJ4382Aw3ALGZKluUQyJkFdrkGfqxoDJo5MLHLu2zlc6g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-projection": "^1.6.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-hierarchy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.4.tgz",
-      "integrity": "sha512-/iSh1YqdgsHFB20QxJ6IAVzRZQBKuMpZ/GsN5sZDP3bBJdVWl3we48L/r6w7FP9NU+JzFHcDUPJ0S0UzpMhaqg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-interpreter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.2.1.tgz",
-      "integrity": "sha512-EMHLGxJ+SWfh1K/fHDRlHEZtLA/2ZNAXItYb5e8CxuAIm/Ha/3DHX/8VlvbTGIciUpuwmcKx4tVhJWlKreQ/Yw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-label": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.2.tgz",
-      "integrity": "sha512-YlUCUZNsp1FHkpPjOpD+aVVmVLFw6xa+bFQGBCECuY1DuRyN6l8oCRmUOjBrr70ip8fbqfGk+czHw543J1PJgg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-lite": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.23.0.tgz",
-      "integrity": "sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "json-stringify-pretty-compact": "~4.0.0",
-        "tslib": "~2.8.1",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.1.1",
-        "vega-util": "~1.17.2",
-        "yargs": "~17.7.2"
-      },
-      "bin": {
-        "vl2pdf": "bin/vl2pdf",
-        "vl2png": "bin/vl2png",
-        "vl2svg": "bin/vl2svg",
-        "vl2vg": "bin/vl2vg"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "vega": "^5.24.0"
-      }
-    },
-    "node_modules/vega-lite/node_modules/vega-expression": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.2.tgz",
-      "integrity": "sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.3"
-      }
-    },
-    "node_modules/vega-loader": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.4.tgz",
-      "integrity": "sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-dsv": "^3.0.1",
-        "node-fetch": "^2.6.7",
-        "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-parser": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.1.tgz",
-      "integrity": "sha512-FIez+huStzgjsxLqOkxDAooTkDC2XruYCIFWhd3HuM/QrqKtj9JKGuIUJjpVVkE7by7S5ejrucpRzVVgQfbzSg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-event-selector": "^3.0.1",
-        "vega-functions": "^5.18.1",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-projection": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.3.tgz",
-      "integrity": "sha512-vusyaPi3EFIHrBVs0chNv2bCqxw4X+XgI1m3+yOgUD/dutsIGTcqy+PjlNlspPQvMI9JjTeIUTGt8u1V7oDwAA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-geo": "^3.1.0",
-        "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^7.4.3"
-      }
-    },
-    "node_modules/vega-regression": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.2.tgz",
-      "integrity": "sha512-DtGToopuJGmxeoymaOXTDKlWkkYiDVvZFV1IWQNuRlChTBI6YBpil4WmA3U+ECePDQuk2+/mWlw+vafrbgF8Tg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-runtime": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.2.tgz",
-      "integrity": "sha512-5c+i7y5XBw5phIA1mBeqF/gtOQcDjUzroUAQ0g3y3weNx0K4mzj7V360yZiBLNcuHv65xgTlijstbKQttxeY/g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-scale": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.3.tgz",
-      "integrity": "sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-scenegraph": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.2.tgz",
-      "integrity": "sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-path": "^3.1.0",
-        "d3-shape": "^3.2.0",
-        "vega-canvas": "^1.2.7",
-        "vega-loader": "^4.5.4",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-schema-url-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
-      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-selections": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
-      "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "3.2.4",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-statistics": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
-      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2"
-      }
-    },
-    "node_modules/vega-themes": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
-      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "vega": "*",
-        "vega-lite": "*"
-      }
-    },
-    "node_modules/vega-time": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.4.tgz",
-      "integrity": "sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-time": "^3.1.0",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-tooltip": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.35.2.tgz",
-      "integrity": "sha512-kuYcsAAKYn39ye5wKf2fq1BAxVcjoz0alvKp/G+7BWfIb94J0PHmwrJ5+okGefeStZnbXxINZEOKo7INHaj9GA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "vega-util": "^1.17.2"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.24.4"
-      }
-    },
-    "node_modules/vega-transforms": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.2.tgz",
-      "integrity": "sha512-VuNLzB0DavFn5GIkFvR2XvwPavjY7VXl2oPUOFvNgSfyQywmCoC7VOX+iHeOdxoZdoy+XEOGAqRs9imxVo2HVA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-typings": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.1.tgz",
-      "integrity": "sha512-40kRoG/jG8+4cd3kT5yw08iTlIGe57F7Go/ileSCtRtgU8RZ7tpPaE6GgYvF/HTPlCKMk9/pOdp62+o5sulhvQ==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "7946.0.4",
-        "vega-event-selector": "^3.0.1",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-typings/node_modules/@types/geojson": {
-      "version": "7946.0.4",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
-      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/vega-util": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
-      "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-view": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.1.tgz",
-      "integrity": "sha512-YyG4i2JDkRCacHd9xNAwyov2cELxwzPGY224PA2o0gEhkoOjPkVElTmo9QHJvKeVxMoyad6wvoq+Jj+TB6zhLw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-format": "^1.1.4",
-        "vega-functions": "^5.18.1",
-        "vega-runtime": "^6.2.2",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-view-transforms": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.2.tgz",
-      "integrity": "sha512-udnYutgX7T7E0crqKWSs4hcxTdUmZHR2F4rKj0+3nN9+CfYMWbGgUkCkP2pMu7j2OH0ETX2uDn5xL8+YJWeXSg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-voronoi": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.5.tgz",
-      "integrity": "sha512-u0TLSQboiLyoM6V9S0E6cc77EfWati+ApZ6zE+NhH3h/zZRzYZmElnDn46hUof2o9jNyh09xFXTXykVHmt7IGg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-wordcloud": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.7.tgz",
-      "integrity": "sha512-xdMykDXdWEp3/7Hil7Yx8uNVmjvqxwGibHJLSfiubNNO9OErrH3ZUgcxWv5hLe9wdK+KSGP94SSqTOAaqH7r/A==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
-      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -9584,17 +9493,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9610,9 +9518,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -9625,13 +9534,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -10269,16 +10181,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
-      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/compiler-sfc": "3.5.38",
-        "@vue/runtime-dom": "3.5.38",
-        "@vue/server-renderer": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -10314,24 +10226,15 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/vue-screen-utils": {
-      "version": "1.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/vue-screen-utils/-/vue-screen-utils-1.0.0-beta.13.tgz",
-      "integrity": "sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": "^3.2.0"
-      }
-    },
     "node_modules/vue-tsc": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.6.tgz",
-      "integrity": "sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.10.tgz",
+      "integrity": "sha512-YaDVxcW+CGtaOt3pZahMG5jYPx0hsUTxyEoPOTSMebcGUXP9lIBabQ14vfKMORb2CqqK5CxsNo/d1d+4IQwiKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.6"
+        "@vue/language-core": "3.3.10"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -10379,15 +10282,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/web-encoding": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
@@ -10431,17 +10325,17 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
+        "@exodus/bytes": "^1.15.1",
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -10527,13 +10421,12 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xml-utils": {
@@ -10622,9 +10515,9 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.2.tgz",
-      "integrity": "sha512-BHP+Z+yemkl9pOogkO1XMOrJ5qI4RNqrmheqJeYtIhpiaW4uvqplYx/jGkMD6edQjIZRQhniFigJZE2oTh7dwQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.4.tgz",
+      "integrity": "sha512-NChufj86SceFj45z4CYjndmI98dphaG7hU8Wj0UGpMyT21o0V3HTY6zo87aSobYWts1tNFivSXzH2AR1AkaWjA==",
       "license": "MIT",
       "dependencies": {
         "@zarrita/storage": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,26 +10,25 @@
     "check": "vue-tsc && eslint ."
   },
   "dependencies": {
-    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@08af85a",
+    "@eodash/eodash": "https://pkg.pr.new/@eodash/eodash@4b0a4d8",
     "@eox/chart": "^1.2.0",
     "@eox/drawtools": "^1.6.0",
     "@eox/elements-utils": "^1.2.0",
-    "@eox/itemfilter": "^1.17.3",
-    "@eox/jsonform": "^1.12.1",
-    "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@7eb12be",
+    "@eox/itemfilter": "^1.17.5",
+    "@eox/jsonform": "^1.12.2",
+    "@eox/layercontrol": "^1.8.2",
     "@eox/layout": "^1.0.0",
-    "@eox/map": "^2.7.0",
+    "@eox/map": "^2.7.2",
     "@eox/storytelling": "^1.13.0",
     "@eox/timecontrol": "^2.6.0",
     "chroma-js": "^3.2.0",
-    "ol": "10.9.0",
-    "stac-js": "^0.1.9"
+    "ol": "10.10.0"
   },
   "devDependencies": {
     "@eox/pages-theme-eox": "^1.9.0",
     "@types/chroma-js": "^3.1.2",
-    "eslint-plugin-vue": "^10.9.2",
-    "typescript": "^5.9.3",
-    "vue-tsc": "^3.3.6"
+    "eslint-plugin-vue": "^10.10.0",
+    "typescript": "^6.0.2",
+    "vue-tsc": "^3.3.10"
   }
 }

--- a/software-services/EOxElements-Jupyter/index.md
+++ b/software-services/EOxElements-Jupyter/index.md
@@ -3,6 +3,10 @@ title: EOxElements Jupyter
 layout: page
 ---
 
+<script setup>
+import { data as items } from '../items.data.js'
+</script>
+
 ## EOxElements Jupyter <img src="/media/eoxelements-jupyter.png" alt="EOxElements-Jupyter Logo" style="height:70px;vertical-align:middle;margin-left:0.5rem;float:right;" />
 
 ### Overview
@@ -60,10 +64,10 @@ EOxElements Jupyter is built on [anywidget](https://anywidget.dev/), which allow
 
 Layers are configured as Python dicts that mirror the JSON configuration used in the web component. This allows you to use the same GeoZarr or STAC configurations across both web and Jupyter environments:
 
-```python
+```python-vue
 from ipyeoxelements import EOxMap
 
-zarr_url = "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance"
+zarr_url = "{{ items.naples.zarrUrl }}/measurements/reflectance"
 
 layers = [
     {

--- a/software-services/eoxelements/advanced.md
+++ b/software-services/eoxelements/advanced.md
@@ -5,8 +5,9 @@ layout: page
 
 <script setup>
 import { useTemplateRef, onMounted, nextTick } from "vue";
+import { data as items } from "../items.data.js";
 
-const zarrUrl = 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance';
+const zarrUrl = `${items.iceland.zarrUrl}/measurements/reflectance`;
 
 // Layer configuration using the layerConfig pattern
 const layers = [
@@ -235,7 +236,7 @@ enabling dynamic style and source updates without custom form components.
 <script type="module" src="config.js"></script>
 ```
 
-```javascript [config.js]
+```javascript-vue [config.js]
 import "@eox/map";
 import "@eox/map/src/plugins/advancedLayersAndSources"
 import "@eox/layercontrol";
@@ -340,7 +341,7 @@ export const layers = [
     },
     source: {
       type: "GeoZarr",
-      url: "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance",
+      url: "{{ items.iceland.zarrUrl }}/measurements/reflectance",
       bands: ["b04", "b03", "b02", "b11"]
     },
     style: {
@@ -378,13 +379,13 @@ Object.assign(eoxMap, {
   });
 ```
 
-```python [Python (Jupyter)]
+```python-vue [Python (Jupyter)]
 %pip install ipyeoxelements  # run once, then restart kernel
 
 from ipywidgets import HBox, Layout
 from ipyeoxelements import EOxMap, EOxLayercontrol
 
-zarr_url = "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr"
+zarr_url = "{{ items.iceland.zarrUrl }}"
 
 layers = [
     {

--- a/software-services/eoxelements/basic.md
+++ b/software-services/eoxelements/basic.md
@@ -5,8 +5,9 @@ layout: page
 
 <script setup>
 import { useTemplateRef, onMounted, nextTick } from "vue"
+import { data as items } from "../items.data.js"
 
-const zarrUrl = 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance';
+const zarrUrl = `${items.iceland.zarrUrl}/measurements/reflectance`;
 
 const layers = [
   {
@@ -159,7 +160,7 @@ This setup includes:
 <script type="module" src="config.js"></script>
 ```
 
-```javascript [config.js]
+```javascript-vue [config.js]
 import "@eox/map";
 import "@eox/map/src/plugins/advancedLayersAndSources"
 
@@ -189,7 +190,7 @@ export const layers = [
         properties: { id: "geozarr", title: "Sentinel-2 GeoZarr" },
         source: {
           type: "GeoZarr",
-          url:"https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance",
+          url:"{{ items.naples.zarrUrl }}/measurements/reflectance",
           bands: ["b04", "b03", "b02"],
         },
         style: {
@@ -233,13 +234,13 @@ const map = document.querySelector("#my-map");
 }
 ```
 
-```python [Python (Jupyter)]
+```python-vue [Python (Jupyter)]
 %pip install ipyeoxelements  # run once, then restart kernel
 
 from ipywidgets import HBox, Layout
 from ipyeoxelements import EOxMap, EOxLayercontrol
 
-zarr_url = "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr"
+zarr_url = "{{ items.naples.zarrUrl }}"
 
 layers = [
     {

--- a/software-services/eoxelements/globe.md
+++ b/software-services/eoxelements/globe.md
@@ -7,6 +7,7 @@ layout: page
 import { onMounted, useTemplateRef, nextTick, ref } from "vue";
 import { inAndOut } from "ol/easing";
 import { transformExtent } from "ol/proj"
+import { data as items } from "../items.data.js"
 
 /** @type {import('vue').Ref<import("@eox/map").EOxMap>} */
 const mapRef = useTemplateRef("mapRef");
@@ -17,11 +18,20 @@ const projection = ref("globe");
 let LonLat;
 
 const cities = [
-  { name: "Brussels", coords: [4.35,50.85], bbox: [4.25, 50.75, 4.45, 50.95], alt: 20000 },
-  { name: "Milano Cortina Winter Olympics", coords: [12.12,46.54], bbox: [12.02, 46.44, 12.22, 46.64], alt: 20000 },
-  { name: "Lyon", coords: [4.83,45.76], bbox: [4.73, 45.66, 4.93, 45.86], alt: 20000 },
-  { name: "Lisbon", coords: [-9.14,38.73], bbox: [-9.24, 38.63, -9.04, 38.83], alt: 20000 }
+  { name: "Brussels", area: "brussels", coords: [4.35,50.85], bbox: [4.25, 50.75, 4.45, 50.95], alt: 20000 },
+  { name: "Milano Cortina Winter Olympics", area: "milanoCortina", coords: [12.12,46.54], bbox: [12.02, 46.44, 12.22, 46.64], alt: 20000 },
+  { name: "Lyon", area: "lyon", coords: [4.83,45.76], bbox: [4.73, 45.66, 4.93, 45.86], alt: 20000 },
+  { name: "Lisbon", area: "lisbon", coords: [-9.14,38.73], bbox: [-9.24, 38.63, -9.04, 38.83], alt: 20000 }
 ];
+
+const rasterUrl = "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items";
+const trueColor = new URLSearchParams([
+  ["variables", "/measurements/reflectance:b04"],
+  ["variables", "/measurements/reflectance:b03"],
+  ["variables", "/measurements/reflectance:b02"],
+  ["rescale", "0,1"],
+  ["color_formula", "gamma rgb 1.3, sigmoidal rgb 6 0.1, saturation 1.2"],
+]).toString();
 
 const layers = [
   {
@@ -36,18 +46,21 @@ const layers = [
       crossOrigin: "anonymous",
     }
   },
-  {
+  // A scene spans about 110 km, so each city needs its own
+  ...cities.map((city) => ({
     type: "Tile",
     properties: {
-      id: "mosaic",
-      title: "Sentinel-2 Mosaic"
+      id: `s2-${city.area}`,
+      title: `Sentinel-2 ${city.name}`
     },
+    // Without this the map requests tiles outside the scene, which 404
+    extent: transformExtent(items[city.area].bbox, "EPSG:4326", "EPSG:3857"),
     source: {
       type: "XYZ",
-      url: 'https://api.explorer.eopf.copernicus.eu/openeo/services/xyz/456c1e23-47f2-4567-98cf-dcde378a05f7/tiles/{z}/{x}/{y}?time=["2025-12-31","2026-01-23"]&cloud_cover=30',
+      url: `${rasterUrl}/${items[city.area].id}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?${trueColor}`,
       crossOrigin: "anonymous",
     }
-  }
+  }))
 ];
 
 /**
@@ -193,7 +206,7 @@ Right click and drag to tilt the globe
 ></eox-map>
 ```
 
-```javascript [config.js]
+```javascript-vue [config.js]
 import "@eox/map";
 import "@eox/map/src/plugins/globe";
 
@@ -216,12 +229,12 @@ map.layers = [
   {
     type: "Tile",
     properties: {
-      id: "mosaic",
-      title: "Sentinel-2 Mosaic"
+      id: "sentinel-2",
+      title: "Sentinel-2 Milano Cortina"
     },
     source: {
       type: "XYZ",
-      url: 'https://api.explorer.eopf.copernicus.eu/openeo/services/xyz/456c1e23-47f2-4567-98cf-dcde378a05f7/tiles/{z}/{x}/{y}?time=["2025-12-31","2026-01-23"]&cloud_cover=30',
+      url: "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/{{ items.milanoCortina.id }}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?variables=/measurements/reflectance:b04&variables=/measurements/reflectance:b03&variables=/measurements/reflectance:b02&rescale=0,1",
       crossOrigin: "anonymous",
     }
   }
@@ -232,7 +245,7 @@ map.globeConfig.terrain = true;
 ```
 
 
-```python [Python (Jupyter)]
+```python-vue [Python (Jupyter)]
 %pip install ipyeoxelements  # run once, then restart kernel
 
 from ipyeoxelements import EOxMap
@@ -249,10 +262,10 @@ layers = [
     },
     {
         "type": "Tile",
-        "properties": {"id": "mosaic", "title": "Sentinel-2 Mosaic"},
+        "properties": {"id": "sentinel-2", "title": "Sentinel-2 Milano Cortina"},
         "source": {
             "type": "XYZ",
-            "url": 'https://api.explorer.eopf.copernicus.eu/openeo/services/xyz/456c1e23-47f2-4567-98cf-dcde378a05f7/tiles/{z}/{x}/{y}?time=["2025-12-31","2026-01-23"]&cloud_cover=30',
+            "url": "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/{{ items.milanoCortina.id }}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?variables=/measurements/reflectance:b04&variables=/measurements/reflectance:b03&variables=/measurements/reflectance:b02&rescale=0,1",
             "crossOrigin": "anonymous",
         },
     },

--- a/software-services/eoxelements/story.md
+++ b/software-services/eoxelements/story.md
@@ -4,8 +4,9 @@ layout: page
 ---
 
 <script setup>
+import { data as items } from "../items.data.js"
 
-const urlNapoli = "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance";
+const urlNapoli = `${items.naples.zarrUrl}/measurements/reflectance`;
 
 /**
  * Creates an array of OpenLayers layer configurations for Sentinel-2 visualization
@@ -126,12 +127,12 @@ This tutorial demonstrates how to use the **eox-storytelling** component to buil
 </html>
 ```
 
-```javascript [main.js]
+```javascript-vue [main.js]
 import "@eox/storytelling";
 import "@eox/map";
 import "@eox/map/src/plugins/advancedLayersAndSources";
 
-const urlNapoli = "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance";
+const urlNapoli = "{{ items.naples.zarrUrl }}/measurements/reflectance";
 
 function createLayers(url, bands) {
   return JSON.stringify([

--- a/software-services/index.js
+++ b/software-services/index.js
@@ -2,6 +2,8 @@
  * Common utilities for integration pages
  */
 
+const STAC_ENDPOINT = "https://api.explorer.eopf.copernicus.eu/stac";
+
 /**
  * @typedef {import('vue').Ref<string>} VueRef
  */
@@ -72,6 +74,109 @@ export function createCopyUrlFunction(buildTileUrlFn) {
       }
     }
   };
+}
+
+/**
+ * Picks the newest scene covering the area centre and at least minSizeKm wide.
+ * A bbox search also returns corner-clipping neighbours and swath-edge strips.
+ *
+ * @param {import("stac-ts").StacItem[]} features
+ * @param {number[]} area - [west, south, east, north]
+ * @param {number} minSizeKm
+ * @returns {import("stac-ts").StacItem | undefined}
+ */
+function pickCovering(features, [west, south, east, north], minSizeKm) {
+  const lon = (west + east) / 2;
+  const lat = (south + north) / 2;
+
+  return features.find(({ bbox }) => {
+    if (!bbox) return false;
+
+    return (
+      bbox[0] <= lon &&
+      bbox[2] >= lon &&
+      bbox[1] <= lat &&
+      bbox[3] >= lat &&
+      (bbox[2] - bbox[0]) * 111 * Math.cos((lat * Math.PI) / 180) >=
+        minSizeKm &&
+      (bbox[3] - bbox[1]) * 111 >= minSizeKm
+    );
+  });
+}
+
+/**
+ * Fetches the newest catalog item matching the search.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.tile] - MGRS tile without prefix, e.g. "32TQR"
+ * @param {number} [options.maxCloud] - Max eo:cloud_cover in percent
+ * @param {string} [options.collection]
+ * @param {number[]} [options.bbox] - [west, south, east, north] in lon/lat
+ * @param {string} [options.datetime] - RFC 3339 instant or interval
+ * @param {object} [options.filter] - Extra CQL2-JSON expression
+ * @param {number} [options.minSizeKm] - Smallest usable scene, per bbox side
+ * @returns {Promise<{id: string, bbox: number[], zarrUrl: string}>}
+ */
+export async function fetchLatestItem(options = {}) {
+  const {
+    tile,
+    maxCloud = 10,
+    collection = "sentinel-2-l2a",
+    bbox,
+    datetime,
+    filter,
+    minSizeKm = 80,
+  } = options;
+
+  const conditions = [];
+  if (tile)
+    conditions.push({
+      op: "=",
+      args: [{ property: "grid:code" }, `MGRS-${tile}`],
+    });
+  conditions.push({
+    op: "<=",
+    args: [{ property: "eo:cloud_cover" }, maxCloud],
+  });
+  if (filter) conditions.push(filter);
+
+  const response = await fetch(`${STAC_ENDPOINT}/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      collections: [collection],
+      // pickCovering needs candidates to choose from
+      limit: bbox ? 20 : 1,
+      sortby: [{ field: "properties.datetime", direction: "desc" }],
+      ...(bbox && { bbox }),
+      ...(datetime && { datetime }),
+      ...(conditions.length && {
+        "filter-lang": "cql2-json",
+        filter:
+          conditions.length === 1
+            ? conditions[0]
+            : { op: "and", args: conditions },
+      }),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`STAC search failed with status ${response.status}`);
+  }
+
+  /** @type {import("stac-ts").StacItem[]} */
+  const features = (await response.json()).features ?? [];
+  const item = bbox ? pickCovering(features, bbox, minSizeKm) : features[0];
+  if (!item)
+    throw new Error(
+      `No ${collection} item covers ${bbox ? `bbox [${bbox}]` : `tile ${tile}`}`,
+    );
+
+  const zarrUrl = item.links.find((link) => link.rel === "store")?.href;
+  if (!item.bbox || !zarrUrl)
+    throw new Error(`${item.id} is missing a bbox or a store link`);
+
+  return { id: item.id, bbox: item.bbox, zarrUrl };
 }
 
 export const checkWebGLSupport = () => {

--- a/software-services/items.data.js
+++ b/software-services/items.data.js
@@ -1,0 +1,51 @@
+import { fetchLatestItem } from "./index.js";
+
+/**
+ * @typedef {Object} AreaItem
+ * @property {string} id - Catalog item id, used to build raster API URLs
+ * @property {number[]} bbox - Scene footprint in lon/lat
+ * @property {string} zarrUrl - Zarr store URL, used by GeoZarr layers
+ */
+
+/**
+ * Replaced at build time by VitePress, which rewrites this module to the
+ * result of load(). The value here only exists so importers can be typed.
+ *
+ * @type {Record<string, AreaItem>}
+ */
+export const data = {};
+
+const COLLECTION = "sentinel-2-l2a";
+
+/**
+ * Areas the examples centre on, as [west, south, east, north] in lon/lat.
+ * Resolved at build time so examples never ship an expired item id.
+ */
+const AREAS = [
+  { name: "venice", bbox: [12.2, 45.3, 12.5, 45.6] },
+  { name: "naples", bbox: [14.0, 41.0, 14.2, 41.2] },
+  { name: "iceland", bbox: [-19.3, 63.3, -19.0, 63.7] },
+  { name: "brussels", bbox: [4.25, 50.75, 4.45, 50.95] },
+  { name: "milanoCortina", bbox: [12.02, 46.44, 12.22, 46.64] },
+  { name: "lyon", bbox: [4.73, 45.66, 4.93, 45.86] },
+  { name: "lisbon", bbox: [-9.24, 38.63, -9.04, 38.83] },
+];
+
+export default {
+  /** @returns {Promise<Record<string, AreaItem>>} */
+  async load() {
+    const items = await Promise.all(
+      AREAS.map((area) =>
+        fetchLatestItem({ collection: COLLECTION, bbox: area.bbox }),
+      ),
+    );
+
+    /** @type {Record<string, any>} */
+    const byArea = {};
+    AREAS.forEach((area, index) => {
+      byArea[area.name] = items[index];
+    });
+
+    return byArea;
+  },
+};

--- a/software-services/ol/basic.md
+++ b/software-services/ol/basic.md
@@ -14,6 +14,7 @@ import GeoZarr from "ol/source/GeoZarr.js"
 import XYZ from "ol/source/XYZ.js"
 import "ol/ol.css"
 import { checkWebGLSupport } from "../index"
+import { data as items } from "../items.data.js"
 
 
 /** @type {import("vue").Ref<boolean | null>} */
@@ -21,7 +22,7 @@ const webglSupport = ref(null)
 const mapRef = ref()
 let map = null
 
-const zarrUrl = "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance"
+const zarrUrl = `${items.naples.zarrUrl}/measurements/reflectance`
 
 
 onMounted(() => {
@@ -139,7 +140,7 @@ This example shows the minimal configuration needed to load and display EOPF Zar
 </html>
 ```
 
-```javascript [main.js]
+```javascript-vue [main.js]
 import Map from "ol/Map.js";
 import {
   getView,
@@ -154,7 +155,7 @@ import GeoZarr from "ol/source/GeoZarr.js";
 import XYZ from "ol/source/XYZ.js";
 
 const zarrUrl =
-  "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance";
+  "{{ items.naples.zarrUrl }}/measurements/reflectance";
 
 // Create GeoZarr source
 const source = new GeoZarr({

--- a/software-services/ol/index.md
+++ b/software-services/ol/index.md
@@ -50,7 +50,7 @@ Ready to dive in? Start with the [Basic Setup example](./basic) to see OpenLayer
 ::: info NPM (Recommended)
 
 ```bash
-npm install ol stac-js@^0.1.2
+npm install ol
 ```
 :::
 

--- a/software-services/ol/ndvi.md
+++ b/software-services/ol/ndvi.md
@@ -16,6 +16,7 @@ import GeoZarr from 'ol/source/GeoZarr.js'
 import XYZ from 'ol/source/XYZ.js'
 import 'ol/ol.css'
 import { checkWebGLSupport } from '../index'
+import { data as items } from '../items.data.js'
 
 
 const sliderRef = useTemplateRef("rangeSlider")
@@ -32,7 +33,7 @@ const maxColor = ref('#00FF00')  // Green
 const minValue = ref(0)
 const maxValue = ref(0.7)
 
-const zarrUrl = 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance'
+const zarrUrl = `${items.naples.zarrUrl}/measurements/reflectance`
 
 // NDVI color scale configuration  
 const segments = 10
@@ -232,7 +233,7 @@ Your browser doesn't support WebGL, which is required for GeoZarr visualization 
 <div id="map" style="width: 100%; height: 500px;"></div>
 ```
 
-```javascript [JavaScript]
+```javascript-vue [JavaScript]
 import { scale as chromaScale } from 'chroma-js';
 import Map from 'ol/Map.js';
 import WebGLTileLayer from 'ol/layer/WebGLTile.js';
@@ -283,7 +284,7 @@ const ndvi = [
 ];
 
 const source = new GeoZarr({
-  url: 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260809T095031_N0512_R079_T33TVF_20260809T150411.zarr/measurements/reflectance',
+  url: '{{ items.naples.zarrUrl }}/measurements/reflectance',
   bands: ['b04', 'b8a'], // Red, NIR
 });
 

--- a/software-services/titiler/crop.md
+++ b/software-services/titiler/crop.md
@@ -17,6 +17,7 @@ import { Draw } from 'ol/interaction.js'
 import { createBox } from 'ol/interaction/Draw.js'
 import { Style, Fill, Stroke } from 'ol/style.js'
 import 'ol/ol.css'
+import { data as items } from '../items.data.js'
 
 const copyUrl = async () => {
   try {
@@ -71,7 +72,7 @@ const bandCombinations = {
   }
 }
 
-const sampleItem = 'S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453'
+const sampleItem = items.venice.id
 const collection = 'sentinel-2-l2a'
 const baseUrl = 'https://api.explorer.eopf.copernicus.eu/raster'
 
@@ -350,11 +351,11 @@ Size Limits: Large crop areas may take longer to process.
 
 ::: code-group
 
-```javascript [Bbox Crop API]
+```javascript-vue [Bbox Crop API]
 // Using the correct bbox API endpoint
 const baseUrl = "https://api.explorer.eopf.copernicus.eu/raster";
 const collection = "sentinel-2-l2a";
-const itemId = "S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453";
+const itemId = "{{ items.venice.id }}";
 
 // Define crop coordinates
 const bbox = "12.2,45.7,12.4,45.9"; // minLon,minLat,maxLon,maxLat

--- a/software-services/titiler/ndvi.md
+++ b/software-services/titiler/ndvi.md
@@ -11,6 +11,7 @@ import TileLayer from 'ol/layer/Tile.js'
 import XYZ from "ol/source/XYZ"
 import { fromLonLat } from 'ol/proj.js'
 import 'ol/ol.css'
+import { data as items } from '../items.data.js'
 
 /**
  * @typedef {Object} VegetationIndex
@@ -85,7 +86,7 @@ const colormaps = [
   { value: 'spectral', name: 'Spectral', description: 'Rainbow spectrum' }
 ]
 
-const sampleItem = 'S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453'
+const sampleItem = items.venice.id
 const collection = 'sentinel-2-l2a'
 const baseUrl = 'https://api.explorer.eopf.copernicus.eu/raster'
 
@@ -335,7 +336,7 @@ This example demonstrates how to calculate vegetation indices using Titiler's se
 
 ::: code-group
 
-```javascript [Map Setup]
+```javascript-vue [Map Setup]
 import Map from 'ol/Map.js';
 import View from 'ol/View.js';
 import TileLayer from 'ol/layer/Tile.js';
@@ -344,7 +345,7 @@ import { fromLonLat } from 'ol/proj.js';
 
 const baseUrl = "https://api.explorer.eopf.copernicus.eu/raster";
 const collection = "sentinel-2-l2a";
-const itemId = "S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453";
+const itemId = "{{ items.venice.id }}";
 
 // Vegetation index expressions
 const expressions = {
@@ -570,12 +571,12 @@ createApp({
 }).mount('#app');
 ```
 
-```javascript [Direct API Usage]
+```javascript-vue [Direct API Usage]
 // Titiler API endpoints for direct usage
 
 const baseUrl = "https://api.explorer.eopf.copernicus.eu/raster";
 const collection = "sentinel-2-l2a";
-const itemId = "S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453";
+const itemId = "{{ items.venice.id }}";
 
 // 1. Get Tile with NDVI Expression
 const ndviExpression = "(/measurements/reflectance:b08-/measurements/reflectance:b04)/(/measurements/reflectance:b08+/measurements/reflectance:b04)";

--- a/software-services/titiler/rgb.md
+++ b/software-services/titiler/rgb.md
@@ -12,6 +12,7 @@ import XYZ from "ol/source/XYZ"
 import { fromLonLat } from 'ol/proj'
 import 'ol/ol.css'
 import { createCopyUrlFunction } from '../index'
+import { data as items } from '../items.data.js'
 
 /**
  * @typedef {Object} BandCombination
@@ -72,9 +73,9 @@ const bandCombinations = {
   }
 }
 
-const sampleItem = 'S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453'
 const collection = 'sentinel-2-l2a'
 const baseUrl = 'https://api.explorer.eopf.copernicus.eu/raster'
+const sampleItem = items.venice.id
 
 /**
  * Builds the Titiler tile URL with current band combination settings
@@ -140,11 +141,9 @@ onMounted(() => {
 function initializeMap() {
   if (!mapContainer.value) return
   
-  const initialUrl = buildTileUrl()
-  
   tileLayer.value = new TileLayer({
     source: new XYZ({
-      url: initialUrl,
+      url: buildTileUrl(),
       crossOrigin: 'anonymous',
       maxZoom: 18
     }),
@@ -167,12 +166,7 @@ function initializeMap() {
     })
   })
   
-  // Add the Titiler layer after map initialization
-  setTimeout(() => {
-    if (tileLayer.value && map.value) {
-      map.value.addLayer(tileLayer.value)
-    }
-  }, 1000)
+  map.value.addLayer(tileLayer.value)
 }
 </script>
 
@@ -231,7 +225,7 @@ This example demonstrates how to create RGB band combinations using Titiler's ti
 
 ::: code-group
 
-```javascript [OpenLayers Integration]
+```javascript-vue [OpenLayers Integration]
 import Map from 'ol/Map.js';
 import View from 'ol/View.js';
 import TileLayer from 'ol/layer/Tile.js';
@@ -240,7 +234,7 @@ import { fromLonLat } from 'ol/proj.js';
 
 // Titiler tile URL with band variables
 const tileUrl =
-  "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" +
+  "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/{{ items.venice.id }}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" +
   "variables=/measurements/reflectance:b04&" +
   "variables=/measurements/reflectance:b03&" +
   "variables=/measurements/reflectance:b02&" +
@@ -264,7 +258,7 @@ const map = new Map({
 });
 ```
 
-```javascript [Leaflet Integration]
+```javascript-vue [Leaflet Integration]
 import L from 'leaflet';
 
 // Create Leaflet map
@@ -275,7 +269,7 @@ L.tileLayer('https://tiles.maps.eox.at/wmts/1.0.0/osm_3857/default/g/{z}/{y}/{x}
 
 // Build Titiler URL
 const tileUrl =
-  "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/S2B_MSIL2A_20260810T101019_N0512_R022_T32TQR_20260810T143453/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" +
+  "https://api.explorer.eopf.copernicus.eu/raster/collections/sentinel-2-l2a/items/{{ items.venice.id }}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" +
   "variables=/measurements/reflectance:b04&" +
   "variables=/measurements/reflectance:b03&" +
   "variables=/measurements/reflectance:b02&" +
@@ -291,11 +285,11 @@ const sentinelLayer = L.tileLayer(tileUrl, {
 sentinelLayer.addTo(map);
 ```
 
-```javascript [API Direct Usage]
+```javascript-vue [API Direct Usage]
 // Direct API calls for custom processing
 const baseUrl = 'https://api.explorer.eopf.copernicus.eu/raster';
 const collection = 'sentinel-2-l2a';
-const itemId = 'S2B_MSIL2A_20260709T110619_N0512_R137_T32VLK_20260709T151414';
+const itemId = '{{ items.venice.id }}';
 
 async function getTileInfo() {
   const response = await fetch(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
     "target": "esnext",
     "allowJs": true,
@@ -10,7 +9,7 @@
     "useDefineForClassFields": true,
     "allowSyntheticDefaultImports": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "jsx": "preserve",
     "sourceMap": false,


### PR DESCRIPTION
Example pages hardcoded Sentinel-2 item IDs, which stop working once the catalog expires them. Items are now resolved from the STAC API at build time.